### PR TITLE
Dev 1

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,5 +1,9 @@
 name: Publish Python Package to PyPI
 
+permissions:
+  contents: write    # pour git push
+  packages: write    # pour publication PyPI
+
 on:
   release:
     types: [created]
@@ -18,12 +22,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: true
     
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing a Python package to PyPI. The changes focus on improving permissions management and ensuring proper setup for testing across multiple Python versions.

Workflow updates for permissions and setup:

* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bR3-R6): Added `permissions` at the workflow level to allow `contents: write` and `packages: write` for Git operations and PyPI publication.
* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bR25-R36): Added `permissions` under the `test` job to allow `contents: read` and `packages: read`, ensuring proper access during the testing phase.
* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bR25-R36): Updated the `actions/checkout@v3` step in the `test` job to include `fetch-depth: 0` for full repository history and `persist-credentials: true` for authentication persistence.