### PR TITLE
docs: add interactive notebooks for Linear Regression and Logistic Regression

### DIFF
--- a/notebooks/classification/logistic_regression.ipynb
+++ b/notebooks/classification/logistic_regression.ipynb
@@ -1,0 +1,1173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Logistic Regression\n",
+    "**IFRI AI Classes**\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Despite its name, **Logistic Regression** is a classification algorithm, not a regression one. It models the probability that a given input belongs to a particular class, and produces binary predictions (0 or 1) by applying a threshold to those probabilities.\n",
+    "\n",
+    "It is one of the most interpretable and widely deployed classifiers in industry, serving as a standard baseline for binary classification tasks in healthcare, finance, marketing, and many other domains.\n",
+    "\n",
+    "The `ifri-mini-ml-lib` implementation uses **gradient descent with momentum** for optimization, includes automatic **polynomial feature expansion** for non-linear decision boundaries, and supports **early stopping** to prevent unnecessary computation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Key Concepts\n",
+    "\n",
+    "### From Linear to Probabilistic\n",
+    "\n",
+    "Linear regression predicts a continuous value $\\hat{y} = \\mathbf{w}^\\top \\mathbf{x} + b$. For classification, we need this output to be a valid probability — a number between 0 and 1. The **sigmoid function** (also called logistic function) achieves exactly this:\n",
+    "\n",
+    "$$\\sigma(z) = \\frac{1}{1 + e^{-z}}$$\n",
+    "\n",
+    "The model computes:\n",
+    "\n",
+    "$$P(y=1 \\mid \\mathbf{x}) = \\sigma(\\mathbf{w}^\\top \\mathbf{x} + b) = \\frac{1}{1 + e^{-(\\mathbf{w}^\\top \\mathbf{x} + b)}}$$\n",
+    "\n",
+    "### Decision Boundary\n",
+    "\n",
+    "A threshold (default: 0.5) is applied to convert probabilities into class labels:\n",
+    "\n",
+    "$$\\hat{y} = \\begin{cases} 1 & \\text{if } P(y=1 \\mid \\mathbf{x}) \\geq 0.5 \\\\ 0 & \\text{otherwise} \\end{cases}$$\n",
+    "\n",
+    "The decision boundary is the set of points where $P(y=1 \\mid \\mathbf{x}) = 0.5$, i.e., where $\\mathbf{w}^\\top \\mathbf{x} + b = 0$.\n",
+    "\n",
+    "### Numerical Stability\n",
+    "\n",
+    "In practice, computing $e^{-z}$ for very large or very small values of $z$ can cause overflow. The implementation clips $z$ to $[-709, 709]$ (the float64 precision boundary) before applying the exponential:\n",
+    "\n",
+    "```python\n",
+    "z_clipped = np.clip(z, -709, 709)\n",
+    "return 1 / (1 + np.exp(-z_clipped))\n",
+    "```\n",
+    "\n",
+    "### Polynomial Feature Expansion\n",
+    "\n",
+    "When the decision boundary is not linear in the original feature space, the `fit` method automatically adds **squared terms** for each feature (when $n_{\\text{features}} \\leq 10$):\n",
+    "\n",
+    "$$\\mathbf{x} = [x_1, x_2, \\ldots, x_n] \\rightarrow [x_1, x_2, \\ldots, x_n, x_1^2, x_2^2, \\ldots, x_n^2]$$\n",
+    "\n",
+    "This allows the model to learn curved, non-linear decision boundaries while keeping the training process linear in the expanded feature space."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Loss Function and Optimization\n",
+    "\n",
+    "### Binary Cross-Entropy Loss\n",
+    "\n",
+    "Logistic regression is trained by minimizing the **Binary Cross-Entropy** (also called log-loss), which measures how well the predicted probabilities match the true binary labels:\n",
+    "\n",
+    "$$\\mathcal{L}(\\mathbf{w}, b) = -\\frac{1}{m} \\sum_{i=1}^{m} \\left[ y_i \\log(\\hat{p}_i) + (1 - y_i) \\log(1 - \\hat{p}_i) \\right]$$\n",
+    "\n",
+    "Where $\\hat{p}_i = \\sigma(\\mathbf{w}^\\top \\mathbf{x}_i + b)$ is the predicted probability for sample $i$.\n",
+    "\n",
+    "A small constant $\\epsilon = 10^{-15}$ is added to prevent $\\log(0)$ from causing numerical issues:\n",
+    "\n",
+    "```python\n",
+    "y_pred = np.clip(y_pred, epsilon, 1 - epsilon)\n",
+    "```\n",
+    "\n",
+    "### Gradient Descent with Momentum\n",
+    "\n",
+    "The gradients of the loss with respect to the parameters are:\n",
+    "\n",
+    "$$\\frac{\\partial \\mathcal{L}}{\\partial \\mathbf{w}} = \\frac{1}{m} X^\\top (\\hat{\\mathbf{p}} - \\mathbf{y}), \\quad \\frac{\\partial \\mathcal{L}}{\\partial b} = \\frac{1}{m} \\sum_{i=1}^{m} (\\hat{p}_i - y_i)$$\n",
+    "\n",
+    "Standard gradient descent updates parameters as $\\mathbf{w} \\leftarrow \\mathbf{w} - \\alpha \\nabla_{\\mathbf{w}}\\mathcal{L}$. The `ifri-mini-ml-lib` implementation adds **momentum** to accelerate convergence and reduce oscillations:\n",
+    "\n",
+    "$$v_w^{(t)} = \\beta \\cdot v_w^{(t-1)} - \\alpha \\cdot \\nabla_{\\mathbf{w}}\\mathcal{L}$$\n",
+    "$$\\mathbf{w}^{(t)} \\leftarrow \\mathbf{w}^{(t-1)} + v_w^{(t)}$$\n",
+    "\n",
+    "Where $\\beta$ is the momentum coefficient (default: `0.9`).\n",
+    "\n",
+    "> **Intuition**: Momentum acts like a ball rolling downhill — it accumulates speed in the direction of consistent gradients and dampens oscillations in directions where gradients frequently change sign.\n",
+    "\n",
+    "### Early Stopping\n",
+    "\n",
+    "The loss is tracked every 10 iterations. If the change in loss between two consecutive checkpoints is smaller than `tol` (default: `1e-4`), training stops early:\n",
+    "\n",
+    "```python\n",
+    "if abs(self.loss_history[-1] - self.loss_history[-2]) < self.tol:\n",
+    "    break\n",
+    "```\n",
+    "\n",
+    "This avoids wasting computation once the model has converged."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Pseudo-algorithm\n",
+    "\n",
+    "```\n",
+    "Input: X         ← matrix of shape [n_samples, n_features]\n",
+    "       y         ← binary labels in {0, 1}, shape [n_samples]\n",
+    "       α         ← learning rate\n",
+    "       β         ← momentum coefficient\n",
+    "       max_iter  ← maximum number of iterations\n",
+    "       tol       ← early stopping tolerance\n",
+    "\n",
+    "# Feature expansion\n",
+    "if n_features ≤ 10:\n",
+    "    X ← column_stack(X, X²)          # Add squared terms\n",
+    "\n",
+    "# Initialization\n",
+    "w ← zeros(n_features_expanded)\n",
+    "b ← 0\n",
+    "v_w ← 0, v_b ← 0                     # Momentum accumulators\n",
+    "loss_history ← []\n",
+    "\n",
+    "for t = 1 to max_iter do\n",
+    "    # Forward pass\n",
+    "    z  ← X · w + b\n",
+    "    p̂  ← sigmoid(z)                  # Predicted probabilities\n",
+    "\n",
+    "    # Backward pass\n",
+    "    dw ← (1/m) · Xᵀ · (p̂ - y)\n",
+    "    db ← (1/m) · sum(p̂ - y)\n",
+    "\n",
+    "    # Momentum update\n",
+    "    v_w ← β · v_w - α · dw\n",
+    "    v_b ← β · v_b - α · db\n",
+    "    w   ← w + v_w\n",
+    "    b   ← b + v_b\n",
+    "\n",
+    "    # Early stopping (every 10 iterations)\n",
+    "    if t mod 10 == 0:\n",
+    "        loss ← cross_entropy(y, p̂)\n",
+    "        loss_history.append(loss)\n",
+    "        if |loss_history[-1] - loss_history[-2]| < tol:\n",
+    "            break\n",
+    "end for\n",
+    "\n",
+    "Return w, b\n",
+    "\n",
+    "# Prediction\n",
+    "function predict(X, threshold=0.5):\n",
+    "    X ← expand_polynomial_features(X)\n",
+    "    p̂  ← sigmoid(X · w + b)\n",
+    "    return (p̂ ≥ threshold).astype(int)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Implementation\n",
+    "\n",
+    "For this implementation, we use the **Breast Cancer Wisconsin** dataset, a standard binary classification benchmark. The task is to predict whether a tumor is malignant (1) or benign (0) from 30 numerical features computed from digitized images of fine needle aspirate biopsies.\n",
+    "\n",
+    "It contains 569 samples and is well-suited to demonstrate logistic regression because the classes are approximately balanced and the features are continuous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset shape  : (569, 30)\n",
+      "Class balance  : {1: 357, 0: 212}\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "mean radius",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean texture",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean perimeter",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean area",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean smoothness",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean compactness",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean concavity",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean concave points",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean symmetry",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean fractal dimension",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "radius error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "texture error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perimeter error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "area error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "smoothness error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "compactness error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "concavity error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "concave points error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "symmetry error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "fractal dimension error",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst radius",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst texture",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst perimeter",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst area",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst smoothness",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst compactness",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst concavity",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst concave points",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst symmetry",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "worst fractal dimension",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "24c8c105-4812-42c4-abeb-417e2de7942c",
+       "rows": [
+        [
+         "0",
+         "17.99",
+         "10.38",
+         "122.8",
+         "1001.0",
+         "0.1184",
+         "0.2776",
+         "0.3001",
+         "0.1471",
+         "0.2419",
+         "0.07871",
+         "1.095",
+         "0.9053",
+         "8.589",
+         "153.4",
+         "0.006399",
+         "0.04904",
+         "0.05373",
+         "0.01587",
+         "0.03003",
+         "0.006193",
+         "25.38",
+         "17.33",
+         "184.6",
+         "2019.0",
+         "0.1622",
+         "0.6656",
+         "0.7119",
+         "0.2654",
+         "0.4601",
+         "0.1189"
+        ],
+        [
+         "1",
+         "20.57",
+         "17.77",
+         "132.9",
+         "1326.0",
+         "0.08474",
+         "0.07864",
+         "0.0869",
+         "0.07017",
+         "0.1812",
+         "0.05667",
+         "0.5435",
+         "0.7339",
+         "3.398",
+         "74.08",
+         "0.005225",
+         "0.01308",
+         "0.0186",
+         "0.0134",
+         "0.01389",
+         "0.003532",
+         "24.99",
+         "23.41",
+         "158.8",
+         "1956.0",
+         "0.1238",
+         "0.1866",
+         "0.2416",
+         "0.186",
+         "0.275",
+         "0.08902"
+        ],
+        [
+         "2",
+         "19.69",
+         "21.25",
+         "130.0",
+         "1203.0",
+         "0.1096",
+         "0.1599",
+         "0.1974",
+         "0.1279",
+         "0.2069",
+         "0.05999",
+         "0.7456",
+         "0.7869",
+         "4.585",
+         "94.03",
+         "0.00615",
+         "0.04006",
+         "0.03832",
+         "0.02058",
+         "0.0225",
+         "0.004571",
+         "23.57",
+         "25.53",
+         "152.5",
+         "1709.0",
+         "0.1444",
+         "0.4245",
+         "0.4504",
+         "0.243",
+         "0.3613",
+         "0.08758"
+        ],
+        [
+         "3",
+         "11.42",
+         "20.38",
+         "77.58",
+         "386.1",
+         "0.1425",
+         "0.2839",
+         "0.2414",
+         "0.1052",
+         "0.2597",
+         "0.09744",
+         "0.4956",
+         "1.156",
+         "3.445",
+         "27.23",
+         "0.00911",
+         "0.07458",
+         "0.05661",
+         "0.01867",
+         "0.05963",
+         "0.009208",
+         "14.91",
+         "26.5",
+         "98.87",
+         "567.7",
+         "0.2098",
+         "0.8663",
+         "0.6869",
+         "0.2575",
+         "0.6638",
+         "0.173"
+        ],
+        [
+         "4",
+         "20.29",
+         "14.34",
+         "135.1",
+         "1297.0",
+         "0.1003",
+         "0.1328",
+         "0.198",
+         "0.1043",
+         "0.1809",
+         "0.05883",
+         "0.7572",
+         "0.7813",
+         "5.438",
+         "94.44",
+         "0.01149",
+         "0.02461",
+         "0.05688",
+         "0.01885",
+         "0.01756",
+         "0.005115",
+         "22.54",
+         "16.67",
+         "152.2",
+         "1575.0",
+         "0.1374",
+         "0.205",
+         "0.4",
+         "0.1625",
+         "0.2364",
+         "0.07678"
+        ]
+       ],
+       "shape": {
+        "columns": 30,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean radius</th>\n",
+       "      <th>mean texture</th>\n",
+       "      <th>mean perimeter</th>\n",
+       "      <th>mean area</th>\n",
+       "      <th>mean smoothness</th>\n",
+       "      <th>mean compactness</th>\n",
+       "      <th>mean concavity</th>\n",
+       "      <th>mean concave points</th>\n",
+       "      <th>mean symmetry</th>\n",
+       "      <th>mean fractal dimension</th>\n",
+       "      <th>...</th>\n",
+       "      <th>worst radius</th>\n",
+       "      <th>worst texture</th>\n",
+       "      <th>worst perimeter</th>\n",
+       "      <th>worst area</th>\n",
+       "      <th>worst smoothness</th>\n",
+       "      <th>worst compactness</th>\n",
+       "      <th>worst concavity</th>\n",
+       "      <th>worst concave points</th>\n",
+       "      <th>worst symmetry</th>\n",
+       "      <th>worst fractal dimension</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>17.99</td>\n",
+       "      <td>10.38</td>\n",
+       "      <td>122.80</td>\n",
+       "      <td>1001.0</td>\n",
+       "      <td>0.11840</td>\n",
+       "      <td>0.27760</td>\n",
+       "      <td>0.3001</td>\n",
+       "      <td>0.14710</td>\n",
+       "      <td>0.2419</td>\n",
+       "      <td>0.07871</td>\n",
+       "      <td>...</td>\n",
+       "      <td>25.38</td>\n",
+       "      <td>17.33</td>\n",
+       "      <td>184.60</td>\n",
+       "      <td>2019.0</td>\n",
+       "      <td>0.1622</td>\n",
+       "      <td>0.6656</td>\n",
+       "      <td>0.7119</td>\n",
+       "      <td>0.2654</td>\n",
+       "      <td>0.4601</td>\n",
+       "      <td>0.11890</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>20.57</td>\n",
+       "      <td>17.77</td>\n",
+       "      <td>132.90</td>\n",
+       "      <td>1326.0</td>\n",
+       "      <td>0.08474</td>\n",
+       "      <td>0.07864</td>\n",
+       "      <td>0.0869</td>\n",
+       "      <td>0.07017</td>\n",
+       "      <td>0.1812</td>\n",
+       "      <td>0.05667</td>\n",
+       "      <td>...</td>\n",
+       "      <td>24.99</td>\n",
+       "      <td>23.41</td>\n",
+       "      <td>158.80</td>\n",
+       "      <td>1956.0</td>\n",
+       "      <td>0.1238</td>\n",
+       "      <td>0.1866</td>\n",
+       "      <td>0.2416</td>\n",
+       "      <td>0.1860</td>\n",
+       "      <td>0.2750</td>\n",
+       "      <td>0.08902</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>19.69</td>\n",
+       "      <td>21.25</td>\n",
+       "      <td>130.00</td>\n",
+       "      <td>1203.0</td>\n",
+       "      <td>0.10960</td>\n",
+       "      <td>0.15990</td>\n",
+       "      <td>0.1974</td>\n",
+       "      <td>0.12790</td>\n",
+       "      <td>0.2069</td>\n",
+       "      <td>0.05999</td>\n",
+       "      <td>...</td>\n",
+       "      <td>23.57</td>\n",
+       "      <td>25.53</td>\n",
+       "      <td>152.50</td>\n",
+       "      <td>1709.0</td>\n",
+       "      <td>0.1444</td>\n",
+       "      <td>0.4245</td>\n",
+       "      <td>0.4504</td>\n",
+       "      <td>0.2430</td>\n",
+       "      <td>0.3613</td>\n",
+       "      <td>0.08758</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>11.42</td>\n",
+       "      <td>20.38</td>\n",
+       "      <td>77.58</td>\n",
+       "      <td>386.1</td>\n",
+       "      <td>0.14250</td>\n",
+       "      <td>0.28390</td>\n",
+       "      <td>0.2414</td>\n",
+       "      <td>0.10520</td>\n",
+       "      <td>0.2597</td>\n",
+       "      <td>0.09744</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14.91</td>\n",
+       "      <td>26.50</td>\n",
+       "      <td>98.87</td>\n",
+       "      <td>567.7</td>\n",
+       "      <td>0.2098</td>\n",
+       "      <td>0.8663</td>\n",
+       "      <td>0.6869</td>\n",
+       "      <td>0.2575</td>\n",
+       "      <td>0.6638</td>\n",
+       "      <td>0.17300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>20.29</td>\n",
+       "      <td>14.34</td>\n",
+       "      <td>135.10</td>\n",
+       "      <td>1297.0</td>\n",
+       "      <td>0.10030</td>\n",
+       "      <td>0.13280</td>\n",
+       "      <td>0.1980</td>\n",
+       "      <td>0.10430</td>\n",
+       "      <td>0.1809</td>\n",
+       "      <td>0.05883</td>\n",
+       "      <td>...</td>\n",
+       "      <td>22.54</td>\n",
+       "      <td>16.67</td>\n",
+       "      <td>152.20</td>\n",
+       "      <td>1575.0</td>\n",
+       "      <td>0.1374</td>\n",
+       "      <td>0.2050</td>\n",
+       "      <td>0.4000</td>\n",
+       "      <td>0.1625</td>\n",
+       "      <td>0.2364</td>\n",
+       "      <td>0.07678</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 30 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mean radius  mean texture  mean perimeter  mean area  mean smoothness  \\\n",
+       "0        17.99         10.38          122.80     1001.0          0.11840   \n",
+       "1        20.57         17.77          132.90     1326.0          0.08474   \n",
+       "2        19.69         21.25          130.00     1203.0          0.10960   \n",
+       "3        11.42         20.38           77.58      386.1          0.14250   \n",
+       "4        20.29         14.34          135.10     1297.0          0.10030   \n",
+       "\n",
+       "   mean compactness  mean concavity  mean concave points  mean symmetry  \\\n",
+       "0           0.27760          0.3001              0.14710         0.2419   \n",
+       "1           0.07864          0.0869              0.07017         0.1812   \n",
+       "2           0.15990          0.1974              0.12790         0.2069   \n",
+       "3           0.28390          0.2414              0.10520         0.2597   \n",
+       "4           0.13280          0.1980              0.10430         0.1809   \n",
+       "\n",
+       "   mean fractal dimension  ...  worst radius  worst texture  worst perimeter  \\\n",
+       "0                 0.07871  ...         25.38          17.33           184.60   \n",
+       "1                 0.05667  ...         24.99          23.41           158.80   \n",
+       "2                 0.05999  ...         23.57          25.53           152.50   \n",
+       "3                 0.09744  ...         14.91          26.50            98.87   \n",
+       "4                 0.05883  ...         22.54          16.67           152.20   \n",
+       "\n",
+       "   worst area  worst smoothness  worst compactness  worst concavity  \\\n",
+       "0      2019.0            0.1622             0.6656           0.7119   \n",
+       "1      1956.0            0.1238             0.1866           0.2416   \n",
+       "2      1709.0            0.1444             0.4245           0.4504   \n",
+       "3       567.7            0.2098             0.8663           0.6869   \n",
+       "4      1575.0            0.1374             0.2050           0.4000   \n",
+       "\n",
+       "   worst concave points  worst symmetry  worst fractal dimension  \n",
+       "0                0.2654          0.4601                  0.11890  \n",
+       "1                0.1860          0.2750                  0.08902  \n",
+       "2                0.2430          0.3613                  0.08758  \n",
+       "3                0.2575          0.6638                  0.17300  \n",
+       "4                0.1625          0.2364                  0.07678  \n",
+       "\n",
+       "[5 rows x 30 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.datasets import load_breast_cancer\n",
+    "from ifri_mini_ml_lib.preprocessing.preparation import DataSplitter\n",
+    "from ifri_mini_ml_lib.preprocessing.preparation import DataSplitter, StandardScaler\n",
+    "\n",
+    "\n",
+    "cancer = load_breast_cancer()\n",
+    "X = pd.DataFrame(cancer.data, columns=cancer.feature_names)\n",
+    "y = pd.Series(cancer.target, name='diagnosis')  # 1 = malignant, 0 = benign\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training set  : 456 samples\n",
+      "Test set      : 113 samples\n"
+     ]
+    }
+   ],
+   "source": [
+    "splitter = DataSplitter(seed=42)\n",
+    "X_train, X_test, y_train, y_test = splitter.train_test_split(X, y, test_size=0.2)\n",
+    "\n",
+    "# Convertir en numpy après le split\n",
+    "X_train, X_test = X_train.values, X_test.values\n",
+    "y_train, y_test = y_train.values, y_test.values\n",
+    "\n",
+    "scaler = StandardScaler()\n",
+    "X_train_scaled = scaler.fit_transform(X_train)\n",
+    "X_test_scaled  = scaler.transform(X_test)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With Scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sklearn.linear_model import LogisticRegression as SklearnLR\n",
+    "\n",
+    "start_1 = time.perf_counter()\n",
+    "sk_model = SklearnLR(max_iter=1000, random_state=42)\n",
+    "sk_model.fit(X_train_scaled, y_train)\n",
+    "end_1 = time.perf_counter()\n",
+    "\n",
+    "y_pred_sk = sk_model.predict(X_test_scaled)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With ifri-mini-ml-lib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ifri_mini_ml_lib.classification import LogisticRegression\n",
+    "\n",
+    "start_2 = time.perf_counter()\n",
+    "lr = LogisticRegression(learning_rate=0.01, max_iter=1000, tol=1e-4, momentum=0.9)\n",
+    "lr.fit(X_train_scaled, y_train)\n",
+    "end_2 = time.perf_counter()\n",
+    "\n",
+    "y_pred_lr = lr.predict(X_test_scaled)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "Metric",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Scikit-learn",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ifri-mini-ml-lib",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "20c37b20-6cbb-4831-ab7b-3faacd0ff023",
+       "rows": [
+        [
+         "Accuracy",
+         "0.9734513274336283",
+         "0.9823008849557522"
+        ],
+        [
+         "F1 Score",
+         "0.979020979020979",
+         "0.9859154929577465"
+        ],
+        [
+         "Recall",
+         "0.9859154929577465",
+         "0.9859154929577465"
+        ],
+        [
+         "Precision",
+         "0.9722222222222222",
+         "0.9859154929577465"
+        ],
+        [
+         "Time (s)",
+         "0.053995",
+         "0.07469"
+        ]
+       ],
+       "shape": {
+        "columns": 2,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Scikit-learn</th>\n",
+       "      <th>ifri-mini-ml-lib</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Metric</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Accuracy</th>\n",
+       "      <td>0.973451</td>\n",
+       "      <td>0.982301</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>F1 Score</th>\n",
+       "      <td>0.979021</td>\n",
+       "      <td>0.985915</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Recall</th>\n",
+       "      <td>0.985915</td>\n",
+       "      <td>0.985915</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Precision</th>\n",
+       "      <td>0.972222</td>\n",
+       "      <td>0.985915</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Time (s)</th>\n",
+       "      <td>0.053995</td>\n",
+       "      <td>0.074690</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Scikit-learn  ifri-mini-ml-lib\n",
+       "Metric                                   \n",
+       "Accuracy       0.973451          0.982301\n",
+       "F1 Score       0.979021          0.985915\n",
+       "Recall         0.985915          0.985915\n",
+       "Precision      0.972222          0.985915\n",
+       "Time (s)       0.053995          0.074690"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from ifri_mini_ml_lib.metrics.evaluation_metrics import accuracy, f1_score, recall, precision\n",
+    "\n",
+    "results = pd.DataFrame({\n",
+    "    'Metric': ['Accuracy', 'F1 Score', 'Recall', 'Precision', 'Time (s)'],\n",
+    "    'Scikit-learn': [\n",
+    "        accuracy(y_test, y_pred_sk),\n",
+    "        f1_score(y_test, y_pred_sk),\n",
+    "        recall(y_test, y_pred_sk),\n",
+    "        precision(y_test, y_pred_sk),\n",
+    "        round(end_1 - start_1, 6)\n",
+    "    ],\n",
+    "    'ifri-mini-ml-lib': [\n",
+    "        accuracy(y_test, y_pred_lr),\n",
+    "        f1_score(y_test, y_pred_lr),\n",
+    "        recall(y_test, y_pred_lr),\n",
+    "        precision(y_test, y_pred_lr),\n",
+    "        round(end_2 - start_2, 6)\n",
+    "    ],\n",
+    "})\n",
+    "\n",
+    "results.set_index('Metric')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAW69JREFUeJzt3Qd4VFXawPE3PUAIAUJCFUQQRKQLYsMVBNRVsSA2QGSxICqyrsLnStFFxFXEgqKu2F1x7aILIkVFWFGQIk1EkCKhp5Be5nveE+4wM5mElEmm3P/veW5m5s6dOyczZ+497z0tzOFwOAQAAAAAqiC8Ki8GAAAAAAILAAAAAD5BjQUAAACAKiOwAAAAAFBlBBYAAAAAqozAAgAAAECVEVgAAAAAqDICCwAAAABVRmABAAAAoMoILIBqcPPNN0urVq0q9drJkydLWFiYz9ME+/KWH48ePSp/+ctfpHHjxia/jR07tsx9LF261Gynt9WtKr+B1157zbx2x44dEii/c02LpknTVtb/qI/HjBkjwcTXx6uqHDtRnIf0OwH8hcACtjvolmepicJTINKTelxcnASLjz76SC6++GJJTEyU6Ohoadq0qVx77bWyePFifyct4D366KOmoHvHHXfIm2++KUOHDvV3klAFVvDyxBNPBPzn+Mcff5jC75o1a3y2Tw1GXI/hderUkZ49e8obb7zhs/cAcGJhDofDUY7tgJDw1ltvuT3Wk87ChQtNwcrVRRddJMnJyZV+n/z8fCkqKpKYmJgKv7agoMAssbGx4o/A4v333zdXswOZHrZuueUWUzDu2rWrXHPNNebK+969e02wsWrVKvnuu+/k7LPP9ndSA4K3/HjWWWdJZGSkLFu2rFz70Nfn5eWZAC48vHqvSVXlN1BYWGj+X/1fq7vmT38vehHiRLUj+vzJJ58sr776qnlNaf+jpvfOO++U5557rsJpsd7jn//8p9x3331SUyrzXf34449y5plnun0eVT12amBRv359+etf/2oe67HgX//6l/zyyy/y0ksvyahRo8QOcnJyzO9aF8AfyHmwlZtuusnt8f/+9z8TWHiu95SVlSW1a9cu9/tERUVVOo2cFE7sySefNEGFNt+ZMWOGWwHywQcfNIGiL06sGsDoibpWrVoSzLzlx/3790uHDh1O+Fr9/61goqaC3ar8BiIiIswS6ELld+7r/6Mqx85mzZq5Hcs1aGndurU89dRTNR5YZGZmmlqTmuaPC1KAK5pCAR4uuOAC6dixo7nqff7555uA4v/+7//Mc5988olceumlpsmNXlE75ZRT5JFHHjFXSctqJ+zaTEGvnunr9PV61e6HH35we21Zba8//vhjkzZ97emnny7z588v8f3pFdQePXqYE4y+z4svvujzdtD/+c9/pHv37qbArc2Q9GS+Z88et21SUlJkxIgR0rx5c5PeJk2ayBVXXOF2dVevXA4YMMDsQ/elV1y1JqIs2dnZMm3aNGnfvr35PL39X9qsR5tBqNL+d29t8fU7+/Of/ywLFiwwn6GmST8//cz/9Kc/ldiHXlnVwozWmLiumzlzpvl+9DvQmq/bbrtNjhw5Iv7imh+tvhLbt2+Xzz//3Nl0RD8H67l3331X/v73v5v/TfN/enp6hfpYWJ+jlRf1czzjjDOcr/3www/NY/18NB/99NNPPvsNVKSPhbVPzc8aZGk6e/fuLevXrzfP63ffpk0bk049Lviy30ZZv8m3335b2rVr5/x8vvnmG5+9rwaUI0eONPlS99+5c2d5/fXXS2x36NAh8zuKj4+XhIQEGT58uKxdu7ZcfUX0Ys25555rXqdNK/V/sY6hmgf0uKf0+GDlP2uf3vpY6G/q6aefduaZRo0aycCBA83xoyy6nR4ntm3bVmJ/5fmN6nb6/+nxXn8HegzYuHGjSZ9rTYuV577++msZPXq0JCUlmeOe5b///a+cd955JtCoW7euOYds2LChWo6X3vpY6O9Lm4zqd6nfR9++fc1FNVfW/6A1vePGjTOfnab3yiuvlAMHDpT5OQOugv9yCVAN9KSqB+LrrrvOFJqtZlF68NUDsx549Vbb8k+cONEUvLQJwom88847kpGRYU5iehB//PHH5aqrrpLffvvthFfqtMmKFsj0xKUnp2eeeUauvvpq2blzpzRs2NB5AtETrp6UpkyZYgKehx9+2JwkfEU/Az0BauFAC/j79u0zJ309Ien7a2FCadr05HnXXXeZE7EWaLTAoem1Hvfv39+kbfz48eZ1ehLV//FEn8Phw4dNbUV1XJnesmWLXH/99eY70qucWigaMmSIOVnryV+bXLmmRduLaz6x6Ousz+juu+82BXht2qKfjX5GVbki6wunnXaaqdG59957TSHGajqi34NViNFgWWsptElNbm6uuV9Rv/76q9xwww3m89DfkAaBl112mcyePdsUMjUfK81D2i9GP/cTNbEqz2+gor799lv59NNPTRMkKz0aFN1///3y/PPPm/fSAqf+VrUQV939d7RwOnfuXJN3tICpadDf9MqVK01AVRUalGuApN+NBlRaMNWgSgvJqampcs899zgL1Ppd6XtqHxwtnOtFFQ0uTkR/8/r5derUyRx79H/Q99O8b+U/Xa/HzVtvvdUUuFVZzRY1ENLflB6TdcABbXql35sWjjVwLY1ut3v3btNEylV5f6MTJkww37t+Flqg18BKb7UWzxvNK/o70v9NayyU/tb0c9PXTZ8+3dR+v/DCCybw0vezgqjqOl7qPvUz1qBC87T+bxowaz7QvNarVy+37fX99fOaNGmS2b8GYJpXNE8C5aJ9LAC7uvPOO7WPkdu6Pn36mHWzZ88usX1WVlaJdbfddpujdu3ajpycHOe64cOHO1q2bOl8vH37drPPhg0bOg4fPuxc/8knn5j1n332mXPdpEmTSqRJH0dHRzt+/fVX57q1a9ea9c8++6xz3WWXXWbSsmfPHue6rVu3OiIjI0vs0xtNd506dUp9Pi8vz5GUlOTo2LGjIzs727l+3rx5Zv8TJ040j48cOWIe//Of/yx1Xx999JHZ5ocffnBUxNNPP21ep68vD2+fp3r11VfNev1uLPqd6br58+e7bbtly5YSn7UaPXq0Iy4uzpkvvv32W7Pd22+/7bad7s/b+primR+VPr700kvd1i1ZssSks3Xr1iXyuvWc3p6I9TkuX77cuW7BggVmXa1atRy///67c/2LL75YYr9V+Q14+15Lo9vFxMS4bWulp3Hjxo709HTn+gkTJpTYr7fP1Rvr969pO9H/qMuPP/7oXKefVWxsrOPKK68s13uU9ZubOXOm2eatt95y+0337t3b5GPr//3ggw/Mdrq9pbCw0HHhhRee8P946qmnzOMDBw6Umg79zXvup7TPdPHixWbbu+++u8S2RUVFzvv6mv79+5v31WX9+vWOoUOHmtfqcd5S3t9oSkqKOW4OGjTIbbvJkyeb7TSdnnnu3HPPdRQUFDjXZ2RkOBISEhyjRo1y24fuu169es71vjxe6jb6nVg0/fq72bZtm3PdH3/84ahbt67j/PPPL/E/9OvXz+1zvffeex0RERGO1NTUMt8XsNAUCvBCr7Lp1SxPrm3ttebh4MGD5mqQXoXavHnzCT9LvfLtevXMulqnNRYn0q9fP9O0yaJXBPUqlPVarZ346quvZNCgQabq3qJNOfRKny9oVbxeOdMrc65tebVqX69qatMa63PSq9za7KG0JkBWzca8efNMh83y0tohpVesq4NexdWri65OPfVU6dKli9tVO/28taO7Xs208oVe/a1Xr57p/K95w1q0OYvWcC1ZskSCgV5hrWq/Em1apM2KLNaV0QsvvFBOOumkEut98RuoDG0W4tr0xkqPXkF2zWMVSWdV6Gem+cWin5U2idHmeZ5NLivqiy++MDVuWiNn0SvYetVeB2zQK9hKm5fpetd+CVqbZNXqlMX6XWsNh9Z8VNUHH3xganf1CronzyZYX375pbmir4s2m9LaAj2Ou9Yml/c3umjRIlPjYdWsuV7RL41+Xq61qFrjoDVB+nm7vpduo/nJeq/qOl5qftHPRM8J2tfEojXaWpuoNYDW8dSitUiun6ueo3Q/v//+e7neEyCwALzQtuXemn9otbK2OdUTkxZo9ARmdRZMS0s74WfpWqBSVpBRnvb3nq+1Xm+9Vgv82tRBAwlP3tZVhnVy0eZBnjSwsJ7XwEyr/bVtsTYj074q2qRAmxJZ+vTpYwpv2mRL2wxr4UlHidGmN2XRz90K7KorsCgtKNRmElZfEi0E6Geu6y1bt241+UDbWFsFHGvRgptuXxr97vTzqcxSnrzni8/Alf4/rmnwbIftmV/1N6NatGjhdb0vfgPe6Gfjmk5tRldd6dTPwPW9KjO6Wtu2bUus08BWL15Uta27/j51/55NzrR5kvW8dauFT88BK8pzHNHfwznnnGOaLOlvX5sJvvfee5UOMrR/hF4oadCgwQm31cK6FuY1MNKmd1oY1+/L9Vhe3t+o9Vl4/s+aDs+mVaX9bvS9rGDa8720wG+9V3UdLzW/aL7xdrzW71y/k127dvnsHAUo+lgAXni7WqtXnvTgrgVbbSOsV071qv3q1avlgQceKNeJs7Q+AeUZ9bkqr/UH7QOhV/O1s61ebX3ooYdM+3Vto65DxOpVMb3ir+2kP/vsM7ONtmHXEZ90XWnzaWgAo7SDrV6JO5HSOsiWdvW3tCv1WmDSNtd6xVP/Ny0saWFT279bNA9ogUU733pTVl8XrQ3xVktW3hoG1w61VVWe2gotuGkhx9KyZUu3jqal5dea/g1ovwHXzsn6G3btgO7LdGq/I9cru3qV3W6TlWne0c7mejVeazC1kK95WwvXWpiuzhG7tMCttVpKax31WKH9PbQPmPaLq+pvtKK/G+ucoDUnrn2zLK6jaVXX8bKigu08g8BDYAGUkxZGtFO3dpbTK0oW7fgXCPRkqYGOdpT05G1dZWjhUWlHWy0ouNJ11vMWDb60c7AuevVOmxPpidB1PhGdT0GXqVOnms7tN954oxmVSK94eqOdHvUq2r///W/TCfhEBRXripsGhlZzAlXRqn29GqkjTWkhSTszaj7QwMZ1vH39f7U5ml6xrWhTIi0I6dXWynBt+lZThg0bZr4LS6AOyasdVl2HIC3tarMvaGFVa54srs1Pysu6yu1K52LQ2oOqDsKgv89169aZAq9rrYXVjNP6/eqtBgaew2yX9zii+9YmZrrocNA6GaMOA6371IJ/RUao09+UFqK1pqk8tRautImmBpL6/tphW0c5Ku9v1Pos9H92rYnQc0B5r95bzfb02GwFPCfa3pfHS80v+v3psdmTfuf6PXnWzAFVRVMooJysAqzrlRudMExHbQmU9OnJS6946UhFFj0xahW7L+gILHqS1JF9XKvgdf+bNm0yJ3KlBRLPkVP0pKlt1q3X6cnZ8yqYnkhVWdX7eqLUGiJ9P731diVNT8Q6oo31vsp1yE4dscXbEJsnorUWenVwzpw5pq20azMopaMbaU2IjqrkSdtra3BTGm16ot9fZZbyzEfha1podk2DFtQCkX42rul07b/ga/oZuL5XZQKLFStWmFpQizZV0f4KOiJQVa/2X3LJJaZ5jWtfIc2Xzz77rLnirYVwK8jVdvwvv/yyczsNRmbNmnXC9/Bsaubtd23N71DW78GizX/0N+5aO1aRq+h6jNBgwPpfyvsb1aBIaxR0BCdXFZm8UD9HreHWwMZbvwiraVt1HS81v2i+0fzjWpuoI/lpUKIXBqympYCvUGMBlJMOh6hXO7XZiXZ21KtuWsUdSFXE2uxCmxtoAUeHidQTqJ4IdZjKNWvWlGsfegL8xz/+UWK9Xi3UjozaFlib7GghRDslWsPNagdYHcLUusKqJ2Y9iWvBTk/QOiO2bmsNzaoFew3KtM+KnkS1z4Se/PVEpwWgsvztb38z/V30ap5eBbVm3tZCkwZWGlQsX77cbKsnVm03rENW6uv0ZKuBgV7N06EcK0L/Hx2CVRf9PDyvQupnoldGtQmDft763toJVq8+ahMq/Zxc57wAPOlvVQukrsPNKm8Fa2+007G34VC1dk075upQozq8rM7To79ZbV6jfYd0WFGrs7puq7VzeuVcL0xokyIdktcKGsqqcdBmohrE60UGveqv/Qj0f9Chja0aLv29a+2hXqDQ99RAQ/tHeOvbo3NH6HwaOrSw/o606aEGOTrcrD6ntYdl0YEr9DPVmhPtfF7e36j2ddBmdHqMufzyy8376nCzehFFm1yVp9ZFj2UamGj6u3XrZo591nFHm4npcVqPz9V5vNRjuTWviB6/dd+aBzQY0X4cgK8RWADlpOPk64gcerLVycM0yNAmFnpC8BxFyF/0aqye+LTgq210tZpbT/R6db88o1ZZtTD6Wk96MtMTkxZKtNbgscceM1cDrUmUNOCwmhrp+2rQoYUcaxZsLZxovwS9Aqn0BK8BgFbj6wlU+ytoYUabk5yo87BW4b/xxhumA6NOOKjt/XV0Ez1pWx0frRGJtNCgJ2lNu/5fGoBoe2b9/irap0ELRxpgakFMmx54m5NCC0v6PejJW5tq6f+uBTjNK4F6VR+BQ38Xmnc1kNACqBY0tf+MjoBVHtqnwdvEmZoHtYCtTTp1HgQtqOpvRjv2aidg1wnfNPjWgq/VP0V/b/ob1z4jmofLmt1ZC+F6ddyq1dNCuP5P+v9YHeD1d6P71T5Lt99+u6kp0DSU9rvX5/T/f+WVV8zFAd2P1p6WNfeFKz0e6v+nxxa9Le9vVI9peqzTArw2n9LvRS/caCG9vDNc6+hL2lRRj5c6OpUW6HVwEB1tyTr+VOfxUicB1CBMP2sNpjQo0yBOa3U957AAfCFMx5z1yZ4ABCy9AqlX+L213waA8tDaQA0wdJhSuwbJ2lRKL0poTYD2GwHgjj4WQIhx7TyqNJjQ8et1plUAqMxxRJtVal8MbXqjzXrs+BkobTKmOJ4C3tEUCggx2mFUq/v1Vkc+0ja+Oo67jo4DAOWhE8FpwVqb/2jzHR0FTfstaUfkQB0BzNe0k7s2Q9M+DNq5XWtqdDQ67Zdh1xob4EQILIAQo50M9eSnHZm186cWDLQw4G3iLQDwRoeT1o7L2q9MO4PrRHFaY3GiztKhRPt1aH8H7bOl/VGsDt3eBrcAUIw+FgAAAACqjD4WAAAAAKqMwAIAAABAldmuj4WO4ayzEuukPOWZ4AYAAACwK4fDYSZl1DlZdF6bstgusNCgQiejAQAAAFA+u3btMhPFlsV2gYXWVFgfjo7H7a9akwMHDphZgk8U+SH0kR9AfgDHB3C+QKCWH3RUNL0ob5Why2K7wMJq/qRBhT8DCx2+T9+fwALkB3B8AOcLUH5AoJcfytOFgMvlAAAAAKqMwAIAAABAlRFYAAAAAKgyAgsAAAAAoRFYzJo1S1q1aiWxsbHSq1cvWblyZanbXnDBBabziOdy6aWX1miaAQAAAARQYDF37lwZN26cTJo0SVavXi2dO3eWAQMGyP79+71u/+GHH8revXudy88//ywREREyePDgGk87AAAAgAAJLGbMmCGjRo2SESNGSIcOHWT27NlSu3ZtmTNnjtftGzRoII0bN3YuCxcuNNsTWAAAAAD+49d5LPLy8mTVqlUyYcIE5zodh7dfv36yYsWKcu3jlVdekeuuu07q1Knj9fnc3FyzuE7yYY39q4s/6Pvq9Oj+en8EFvIDyA/g+ADOFwjU8kNF9u/XwOLgwYNSWFgoycnJbuv18ebNm0/4eu2LoU2hNLgozbRp02TKlCkl1utMhTqpiD/oF5SWlmYyAxPkgfwAjg/gfAHKDwjU8kNGRka5tw3qmbc1oDjjjDOkZ8+epW6jtSHah8NzWnKd/twfM28fOZor+1KzZF92hCQ1S5D6cbE1ngYE3oFBByDQPEmgCfIDOD6A8wUC6XyhgysFRWCRmJhoOl7v27fPbb0+1v4TZcnMzJR3331XHn744TK3i4mJMYsn/QL8UYhbuG6PvLpki7k/8Zq6cs5ptWs8DQg8emDwV55E4CE/gPwAjg8IlPNFRfbt11JMdHS0dO/eXRYtWuQWfenj3r17l/na//znP6bvxE033STBJCYqwnk/J7/Qr2kBAAAAfMXvTaG0mdLw4cOlR48epknTzJkzTW2EjhKlhg0bJs2aNTN9JTybQQ0aNEgaNmwowSQ2+nhgkUtgAQAAgBDh98BiyJAhpiP1xIkTJSUlRbp06SLz5893dujeuXNniSqYLVu2yLJly+TLL7+UYBMT6RJYFFBjAQAAgNDg98BCjRkzxizeLF26tMS6du3amR7wwSjWpSkUNRYAAAAIFfQUrWH0sQAAAEAoIrDwY2BBjQUAAABCBYFFDaPGAgAAAKGIwMKvfSyqdwp2AAAAoKYQWNQwmkIBAAAgFBFY1DBGhQIAAEAoIrCoYfSxAAAAQCgisKhh0ZHhEnbsPqNCAQAAIFQQWNSwsLAwZ60FM28DAAAgVBBY+IEzsMgv9MfbAwAAAD5HYOEHBBYAAAAINQQWfhATVfyx51BjAQAAgBBBYOEHsZHHm0I5HA5/JAEAAADwKQILP4iJLg4sihwi+YXMvg0AAIDgR2DhxxoLlZtPYAEAAIDgR2Dh50nyGBkKAAAAoYDAwg8ILAAAABBqCCz8HFjk5Bf4IwkAAACATxFY+D2wYJI8AAAABD8CCz+IdetjQedtAAAABD8CCz+gjwUAAABCDYGFH2feVowKBQAAgFBAYOEHMa7zWBTQxwIAAADBj8DCz30scvIYFQoAAADBj8DC76NC0XkbAAAAwY/Awu+jQtEUCgAAAMGPwMLfo0LRxwIAAAAhgMDCDxhuFgAAAKGGwMLffSzyaAoFAACA4Edg4ffO2wQWAAAACH4EFv7uvE0fCwAAAIQAAgs/oI8FAAAAQo3fA4tZs2ZJq1atJDY2Vnr16iUrV64sc/vU1FS58847pUmTJhITEyOnnnqqfPHFFxJMoiOPf+wMNwsAAIBQEOnPN587d66MGzdOZs+ebYKKmTNnyoABA2TLli2SlJRUYvu8vDy56KKLzHPvv/++NGvWTH7//XdJSEiQYBIeFibREWGSV+ig8zYAAABCgl8DixkzZsioUaNkxIgR5rEGGJ9//rnMmTNHxo8fX2J7XX/48GFZvny5REVFmXVa2xGMtNYir7CQPhYAAAAICX5rCqW1D6tWrZJ+/fodT0x4uHm8YsUKr6/59NNPpXfv3qYpVHJysnTs2FEeffRRKSwsDNp+FjSFAgAAQCjwW43FwYMHTUCgAYIrfbx582avr/ntt99k8eLFcuONN5p+Fb/++quMHj1a8vPzZdKkSV5fk5ubaxZLenq6uS0qKjKLP+j7alMoa7hZf6UDgUG/f4fDQT4A+QEcH8D5AgFXfqjI/v3aFKoy/5j2r3jppZckIiJCunfvLnv27JF//vOfpQYW06ZNkylTppRYf+DAAcnJyRF//R8RYQ5zPzevQPbv3++XdCAwaH5IS0szBwettYO9kR9AfgDHBwTS+SIjIyPwA4vExEQTHOzbt89tvT5u3Lix19foSFDat0JfZznttNMkJSXFNK2Kjo4u8ZoJEyaYDuKuNRYtWrSQRo0aSXx8vPgrI9SO+UUbhEmhQ6RBw0SJjKBAaVeaH8LCwkyeJLAA+QEcH8D5AoF0vtCRWwM+sNAgQGscFi1aJIMGDXJ+QPp4zJgxXl9zzjnnyDvvvGO2sz7AX375xQQc3oIKpUPS6uJJX+/PQlx05PHgSEeHio4isLAzPTD4O08icJAfQH4AxwcEyvmiIvv2aylGaxJefvllef3112XTpk1yxx13SGZmpnOUqGHDhpkaB4s+r6NC3XPPPSag0BGktPO2duYONjEugQQduAEAABDs/NrHYsiQIaavw8SJE01zpi5dusj8+fOdHbp37tzpFiVpE6YFCxbIvffeK506dTLzWGiQ8cADD0iwcZ0kTztwAwAAAMHM7523tdlTaU2fli5dWmKdDjf7v//9T4Ids28DAAAglNCg209iXGosaAoFAACAYEdg4Sc0hQIAAEAoqXJgoZPcrVmzRo4cOeKbFNlEtMvwstRYAAAAwHaBxdixY+WVV15xBhV9+vSRbt26mY7V3vpE4MSjQtF5GwAAALYLLN5//33p3Lmzuf/ZZ5/J9u3bZfPmzWakpgcffLA60hiS6GMBAAAAWwcWBw8edM6M/cUXX8jgwYPl1FNPlVtuuUXWr19fHWkMSYwKBQAAAFsHFjrHxMaNG00zKJ1z4qKLLjLrs7KyJCLi+GzSKBudtwEAAGDreSx0Vuxrr71WmjRpYqYR79evn1n//fffS/v27asjjSGJGgsAAADYOrCYPHmydOzYUXbt2mWaQcXExJj1Wlsxfvz46khjSKKPBQAAAMTuM29fc801bo9TU1Nl+PDhvkqT7QILRoUCAACA7fpYTJ8+XebOnet8rM2iGjZsKM2bN5d169b5On0hi6ZQAAAAsHVgMXv2bDNnhVq4cKFZ/vvf/8rAgQPlvvvuq440hiQCCwAAANi6KVRKSoozsJg3b56psejfv7+0atVKevXqVR1pDEk0hQIAAICtayzq169vOm4rHW7WGhXK4XCYIWhRPtRYAAAAwNY1FldddZXccMMN0rZtWzl06JBcfPHFZv1PP/0kbdq0qY40hiQCCwAAANg6sHjqqadMsyettXj88cclLi7OrN+7d6+MHj26OtIYksLDwkxwkVdQxKhQAAAAsF9gERUV5bWT9r333uurNNlGTFSECSxyC2hCBgAAABvOY7Ft2zaZOXOmbNq0yTzu0KGDjB07Vlq3bu3r9IW0mMgIyZB8yckjsAAAAIDNOm8vWLDABBIrV66UTp06meX7778363ToWVSsxkLl5hNYAAAAwGY1FuPHjzfNnh577LES6x944AG56KKLfJm+kBZLYAEAAAC71lho86eRI0eWWH/LLbfIxo0bfZUuW9VYFBQ5pKCwyN/JAQAAAGousGjUqJGsWbOmxHpdl5SUxFdRATFRxz9+OnADAADAVk2hRo0aJbfeeqv89ttvcvbZZ5t13333nUyfPl3GjRtXHWkM+aZQSjtw14mJ8mt6AAAAgBoLLB566CGpW7euPPnkkzJhwgSzrmnTpjJ58mS55557Kp0QOzeFUnTgBgAAgK2aQoWFhZnO27t375a0tDSz6H2tyVi+fHn1pNIGNRYEFgAAALDdPBYWrbmwbN26Vc477zwpLGTo1ErVWDBJHgAAAOxUY4HqCSxymMsCAAAAQYzAws8zb1toCgUAAIBgRmARKDUWeTQhAwAAgA36WHz66adlPr99+3ZfpMdWmMcCAAAAtgssBg0aVK4Ro1B+sVHHP36aQgEAAMAWgUVRUVH1psTmNRZ03gYAAEAwo49FwEyQR+AGAACA4BUQgcWsWbOkVatWEhsbK7169ZKVK1eWuu1rr71mmly5Lvq6YJ8gLyevwK9pAQAAAII6sJg7d66MGzdOJk2aJKtXr5bOnTvLgAEDZP/+/aW+Jj4+Xvbu3etcfv/9dwn64WaZIA8AAABBzO+BxYwZM2TUqFEyYsQI6dChg8yePVtq164tc+bMKfU1WkvRuHFj55KcnCzBKDaaeSwAAAAQGvwaWOTl5cmqVaukX79+xxMUHm4er1ixotTXHT16VFq2bCktWrSQK664QjZs2CDBiD4WAAAAsN2oUJbhw4fLyJEj5fzzz6/ymx88eFAKCwtL1Djo482bN3t9Tbt27UxtRqdOnSQtLU2eeOIJOfvss01w0bx58xLb5+bmmsWSnp7uHOXKXyNd6fs6HA6Jighz62PByFv2ZOUHvn+QH8DxAZwvEGjlh4rsv8KBhRbmtUZBawy0+ZIGGs2aNZOa0rt3b7NYNKg47bTT5MUXX5RHHnmkxPbTpk2TKVOmlFh/4MABycnJEX/QL0g/x+jc4x22M7Kyy+xXgtBl5Qc9OGiNHeyN/ADyAzg+IJDOFxkZGdUXWHz88cemUP7mm2/K66+/bjpda6ChtRjaLCkqKqrc+0pMTJSIiAjZt2+f23p9rH0nykPfr2vXrvLrr796fX7ChAmmc7hrjYU2oWrUqJHpBO6vjKD9RBo0bHh8nURIUlKSX9ID/7Lyg+ZJAguQH8DxAZwvEEjni4qMvlrhwELpP6CFdV10JKdXX31Vhg4dKnFxcXLTTTfJ6NGjpW3btifcT3R0tHTv3l0WLVrknNlbPyR9PGbMmHKlRZtSrV+/Xi655BKvz8fExJjFk34B/izEaUaIioyUqIhwyS8sktyCIgqVNqb5wd95EoGD/ADyAzg+IFDOFxXZd5VSoUO9Lly40Cxa86CFey3k6+hOTz31VLn2ocHJyy+/bGo/Nm3aJHfccYdkZmaaZlZq2LBhptbB8vDDD8uXX34pv/32mwlqNJDR4Wb/8pe/SDB34M7NL/R3UgAAAIBKq3CNRX5+vnz66aemlkIL+NqJeuzYsXLDDTc4mxZ99NFHcsstt8i99957wv0NGTLENK2aOHGipKSkSJcuXWT+/PnODt07d+50i5SOHDlihqfVbevXr29qPJYvX26CmWCdJO9oTj6BBQAAAOwVWDRp0sQ0V7r++uvNDNkaCHj605/+JAkJCeXepzZ7Kq3p09KlS90ea01IeWtDgqnGIocaCwAAANgpsNBC/eDBg8vsyKFBxfbt26uaNlugKRQAAABsGVhoJ23Lrl27zK2OsoTKiYkqbualHbgLi4okgs67AAAACEIV7rxdUFAgDz30kNSrV09atWplFr3/97//3fS/QMXERh2P7XLz/TNhHwAAAFDjNRZ33XWXfPjhh/L44487J6pbsWKFTJ48WQ4dOiQvvPBClRNlx6ZQ1shQtWMqNQIwAAAA4FcVLsW+88478u6778rFF1/sXKcjQ2lzKO3QTWBR8VGhLAw5CwAAANs0hdLJ5rT5k6eTTz7ZTHiHyvWxUIwMBQAAANsEFjos7COPPCK5ubnOdXp/6tSp5Z4tG96bQhFYAAAAwDZNoX766SdZtGiRNG/eXDp37mzWrV27VvLy8qRv375y1VVXObfVvhioSOdtZt8GAACATQILnaPi6quvdlvHcLO+67wNAAAA2CKwePXVV6snJTbl2seCwAIAAADBqtJjmx44cEC2bNli7rdr104aNWrky3TZclQo+lgAAADANp23MzMz5ZZbbpEmTZrI+eefb5amTZvKyJEjJSsrq3pSGcLovA0AAABbBhbjxo2Tr7/+Wj777DNJTU01yyeffGLW/fWvf62eVIawmEj6WAAAAMCGTaE++OADef/99+WCCy5wrrvkkkukVq1acu211zJBXgXFRhNYAAAAwIY1FtrcKTk5ucT6pKQkmkJVAqNCAQAAwJaBRe/evWXSpEmSk5PjXJednS1Tpkwxz6HynbdzCxhuFgAAADZpCjVz5kwZOHBgiQnyYmNjZcGCBdWRRtv0scjJI7AAAACATQKLM844Q7Zu3Spvv/22bN682ay7/vrr5cYbbzT9LFAxjAoFAAAA2wUW+fn50r59e5k3b56MGjWq+lJlI3TeBgAAgO36WERFRbn1rYCPO2/TxwIAAAB26bx95513yvTp06WgoKB6UmQzzGMBAAAAW/ax+OGHH2TRokXy5Zdfmv4WderUcXv+ww8/9GX6Ql5kRLhEhodJQZGDztsAAACwT2CRkJAgV199dfWkxsbNoQpyCyQ3n1GhAAAAYJPA4tVXX62elNg8sMjMLZAc+lgAAADALn0sLrzwQklNTS2xPj093TyHyo8MRY0FAAAAbBNYLF26VPLy8kqs19Givv32W1+ly5YduAksAAAAEPJNodatW+e8v3HjRklJSXE+LiwslPnz50uzZs18n0IbiD025GxeQZEUORwSHhbm7yQBAAAA1RNYdOnSRcLCwszircmTzrr97LPPVuzdUXIui/xCqRVd4a4vAAAAgF+VuwS7fft2cTgc0rp1a1m5cqU0atTI+Vx0dLQkJSVJRMTxAjLKj8ACAAAAtgksWrZsaW6LioqqMz22bgqlchhyFgAAAEGoUm1utm7dKkuWLJH9+/eXCDQmTpzoq7TZtsYCAAAACPnA4uWXX5Y77rhDEhMTpXHjxqbPhUXvE1hUHIEFAAAAbBdY/OMf/5CpU6fKAw88UD0psiGaQgEAAMB281gcOXJEBg8e7NNEzJo1S1q1aiWxsbHSq1cv0zm8PN59911TSzJo0CAJZtRYAAAAwHaBhQYVX375pc8SMHfuXBk3bpxMmjRJVq9eLZ07d5YBAwaY/htl2bFjh9x3331y3nnnSbCjxgIAAAC2awrVpk0beeihh+R///ufnHHGGRIVFeX2/N13312h/c2YMUNGjRolI0aMMI9nz54tn3/+ucyZM0fGjx/v9TU6Id+NN94oU6ZMMbN9p6amSjCjxgIAAAC2CyxeeukliYuLk6+//tosrrRZUkUCi7y8PFm1apVMmDDBuS48PFz69esnK1asKPV1Dz/8sJk3Y+TIkSawCHYEFgAAALBdYKET5fnKwYMHTe1DcnKy23p9vHnzZq+vWbZsmbzyyiuyZs2acr1Hbm6uWSzp6enmVofJ9decHPq+Otmg9f7RkcdbpOXkFTBXiM145gfYG/kB5AdwfEAgnS8qsv9KzWPhLxkZGTJ06FAz5K0Od1se06ZNM02mPB04cEBycnLEH/QLSktLM5lBa2hyMjOczx08kn7C/iUILZ75AfZGfgD5ARwfEEjnCy1/+zyw6NChg6ktaNCggXk8evRo0yTJKuBrYVhHdsrKyir3m+trIyIiZN++fW7r9bHOkeFp27ZtptP2ZZddViKKioyMlC1btsgpp5zi9hptZqWdw11rLFq0aCGNGjWS+Ph48QdNszYb0zRoRkjK1MywzTwXFRNrmnnBPjzzA+yN/ADyAzg+IJDOFzpqq88DC22aVFBQ4Hz81ltvmVGZrMBCo6WK1gBER0dL9+7dZdGiRc4hY/VD0sdjxowpsX379u1l/fr1buv+/ve/m0jq6aefNgGDp5iYGLN40i/An4U4zQhWGmrHHO8An1tQROHShlzzA0B+AMcHcL5AoJwvKrLvSjeF0kDCk+ss3OWltQnDhw+XHj16SM+ePWXmzJmSmZnpHCVq2LBh0qxZM9OkSSOmjh07ur0+ISHB3HquDyZ03gYAAECw83sfiyFDhpj+DhMnTpSUlBTp0qWLzJ8/39mhe+fOnSF/FZfAAgAAALYJLLQ2wrNGojI1FN5osydvTZ/U0qVLy3zta6+9JsGOCfIAAABgm8BCmz717dvXdJJW2dnZphO19pNQrv0vUDHUWAAAAMA2gcWkSZPcHl9xxRUltrn66qt9kyqbocYCAAAAtg0s4MMvISJcIsLDpLDIIbn5hXy0AAAACDpV6hX92GOPSWpqqu9SY2NWcygCCwAAANgusHj00Ufl8OHDvkuNjVnNoXKosQAAAIDdAgtvc1mgcqixAAAAQDAL7QkigkhMJE2hAAAAYNMJ8jZu3GhmxUbVxUYfCywKiqTI4ZBwH80RAgAAAARkjcWuXbtk9+7d5n6LFi3kxx9/lLFjx8pLL71UHemz5VwWeQVFfk0LAAAAUO2BxQ033CBLliwx91NSUuSiiy6SlStXyoMPPigPP/xwhROAYkySBwAAAFsFFj///LP07NnT3H/vvfekY8eOsnz5cnn77bfltddeq4402qqPhcrJYxZzAAAAhHhgkZ+fLzExMeb+V199JZdffrm53759e9m7d6/vU2jD2beZywIAAAAhH1icfvrpMnv2bPn2229l4cKFMnDgQLP+jz/+kIYNG1ZHGm3VedvqwA0AAACEdGAxffp0efHFF+WCCy6Q66+/Xjp37mzWf/rpp84mUqhaHwsmyQMAAEDIDzerAcXBgwclPT1d6tev71x/6623Su3atX2dPlv2saApFAAAAEK+xiI7O1tyc3OdQcXvv/8uM2fOlC1btkhSUlJ1pNF+NRZ03gYAAECoBxZXXHGFvPHGG+Z+amqq9OrVS5588kkZNGiQvPDCC9WRRluIjTr+VVBjAQAAgJAPLFavXi3nnXeeuf/+++9LcnKyqbXQYOOZZ56pjjTaQmz08VZpdN4GAABAyAcWWVlZUrduXXP/yy+/lKuuukrCw8PlrLPOMgEGfDCPRX4hHyMAAABCO7Bo06aNfPzxx7Jr1y5ZsGCB9O/f36zfv3+/xMfHV0cabYGZtwEAAGCrwGLixIly3333SatWrczwsr1793bWXnTt2rU60mgLdN4GAACArYabveaaa+Tcc881s2xbc1iovn37ypVXXunr9NlGjGvnbSbIAwAAQKgHFqpx48Zm2b17t3ncvHlzJseroliX4WYZFQoAAAAh3xSqqKhIHn74YalXr560bNnSLAkJCfLII4+Y51A5sVEuo0LReRsAAAChXmPx4IMPyiuvvCKPPfaYnHPOOWbdsmXLZPLkyZKTkyNTp06tjnTaq48FgQUAAABCPbB4/fXX5V//+pdcfvnlznWdOnWSZs2ayejRowksKolRoQAAAGCrplCHDx+W9u3bl1iv6/Q5VL3zNjUWAAAACPnAQkeCeu6550qs13Wuo0ShYqIiwiU8rPg+fSwAAAAQ8k2hHn/8cbn00kvlq6++cs5hsWLFCjNh3hdffFEdabSFsLAw04E7K6+AwAIAAAChX2PRp08f+eWXX8ycFampqWa56qqrZMuWLXLeeedVTypt1s+CGgsAAACEdI1Ffn6+DBw4UGbPnk0n7WrsZ0EfCwAAAIR0jUVUVJSsW7eu+lJjc3VrRZvbjOw8KShkThAAAACEcFOom266ycxjAd9Lio81t0UOkYMZOXzEAAAACN3AoqCgQF544QXp0aOH3HbbbTJu3Di3pTJmzZolrVq1ktjYWOnVq5esXLmy1G0//PBD894623edOnWkS5cu8uabb0ooSEqo7by/Py3br2kBAAAAqnVUqJ9//lm6detm7msnbs+RjSpq7ty5JiDRfhsaVMycOVMGDBhgOoMnJSWV2L5BgwZm9m+dNyM6OlrmzZsnI0aMMNvq64JZUr1azvsEFgAAAAjpwGLJkiU+TcCMGTNk1KhRJjhQGmB8/vnnMmfOHBk/fnyJ7S+44AK3x/fcc4+ZDXzZsmVBH1gkE1gAAAAg1AOLwsJC2bBhg7Rt21Zq1Tp+ZV1lZ2fL1q1bpWPHjhIeXv7WVXl5ebJq1SqZMGGCc52+vl+/fmZujBNxOByyePFiU7sxffp0r9vk5uaaxZKenm5ui4qKzOIP+r6ads/3T6wb47y/LzXLb+lDYOQH2BP5AeQHcHxAIJ0vKrL/cgcW2o9BZ9f+/vvvvY4Wdcstt8jYsWNN5+7yOnjwoAlYkpOT3dbr482bN5f6urS0NGnWrJkJGCIiIuT555+Xiy66yOu206ZNkylTppRYf+DAAcnJ8U8Haf2C9H/QzOAaiIXnFzjv7zqQJvv37/dL+hAY+QH2RH4A+QEcHxBI54uMjAzfBxY6EtR9991nCvIldhIZKffff78JPCoSWFRW3bp1Zc2aNXL06FFZtGiR6aPRunXrEs2klNaGuHYq1xqLFi1aSKNGjSQ+Pl78lRG0P4qmwTUjNHI4JCbqZzNBXlpOkdc+Jgg9peUH2BP5AeQHcHxAIJ0vdHAlnwcW2tzorLPOKvX5M888UzZt2iQVkZiYaAKVffv2ua3Xx40bNy71dfrhtWnTxtzXUaH0fbVmwltgERMTYxZv+/BnIU4zgrc0aD+LnQePyoG0bLNNZTrEI/iUlh9gT+QHkB/A8QGBcr6oyL7LvWVmZqazf0Jp1SRZWVlSETqqU/fu3U2tg2v0pY979+5d7v3oa1z7UYTCyFC5BUWSlpXn7+QAAAAAvq2x0E7by5cvl06dOnl9Xkdl0m0qSpspDR8+3MxN0bNnTzPcrAYx1ihRw4YNM/0ptEZC6a1ue8opp5hg4osvvjD9P3RujVDgOuTsvrRsSahTsrYFAAAACNrA4oYbbpC///3vcvbZZ5cILtauXSsTJ040/SwqasiQIaYjtb4+JSXFNG2aP3++s0P3zp073apgNOgYPXq07N6924xOpfNZvPXWW2Y/ocBtLovUbGnXNMGv6QEAAADKI8yhXcnLIT8/X/r3729qJnQ4WC3QKx296auvvpJzzjlHFi5caEaICmTanKtevXqmF70/O2/riE/aOduz3dri9Xtk+sdrzP1bLzpNrj6rtV/SiMDID7Af8gPID+D4gEA6X1Sk7FzuGgsNGL788kt56qmn5J133pFvvvnGDG916qmnytSpU81Qs4EeVAQDZt8GAABAyM+8rYGDNneqTJMnVKKPRWo2HxsAAACCAu0uAkzDurESfmyI2f1pBBYAAAAIDgQWASYiPEwaxcc6R4UCAAAAggGBRQA3hzqaky9ZuQX+Tg4AAABwQgQWAYgO3AAAAAj5wGLJkiXVkxI4JbvOZUFzKAAAAIRiYDFw4EAz6/U//vEP2bVrV/WkyuaSEtxn3wYAAABCLrDYs2ePjBkzRt5//31p3bq1DBgwQN577z3Jy8urnhTaUFI8NRYAAAAI8cAiMTFR7r33XlmzZo18//33ZoK80aNHS9OmTeXuu++WtWvXVk9KbYQ+FgAAALBV5+1u3brJhAkTTA3G0aNHZc6cOdK9e3c577zzZMOGDb5Lpc0QWAAAAMAWgUV+fr5pCnXJJZdIy5YtZcGCBfLcc8/Jvn375NdffzXrBg8e7PvU2kRMVIQk1Ik29+m8DQAAgGAQWdEX3HXXXfLvf/9bHA6HDB06VB5//HHp2LGj8/k6derIE088YZpGoWq1FqmZeXIoI0fyC4skKoKRgQEAABBCgcXGjRvl2WeflauuukpiYmJK7YfBsLRVH3L2lz/SxCEiB9NzpEn92lXcIwAAAFB9wivaBEqbOZ111lmlBhUqMjJS+vTp44v02VYj5rIAAABAqAYWUVFR8sEHH1RfauDEJHkAAAAIJhVuuD9o0CD5+OOPqyc18DoyFJPkAQAAIOT6WLRt21Yefvhh+e6778zQstpZ25XOZQFf11hk8ZECAAAgtAKLV155RRISEmTVqlVmcRUWFkZg4SNJ9Y531qbGAgAAACEXWGzfvr16UgI3cbGRUis6QrLzCuVAWg6fDgAAAAIakyMEKK39sfpZ6CR5RQ4deBYAAAAIkRoLtXv3bvn0009l586dkpeX5/bcjBkzfJU229N+Fr8fOGomyEvNzJUGcbG2/0wAAAAQIoHFokWL5PLLL5fWrVvL5s2bzazbO3bsMDNxd+vWrXpSaVOuI0NprQWBBQAAAEKmKdSECRPkvvvuk/Xr10tsbKyZ12LXrl1mQrzBgwdXTyptyq0Dd2q2X9MCAAAA+DSw2LRpkwwbNsw5w3Z2drbExcWZIWinT59e0d2hvEPOphNYAAAAIIQCC523wupX0aRJE9m2bZvzuYMHD/o2dTbXqF6sW1MoAAAAIGT6WJx11lmybNkyOe200+SSSy6Rv/71r6ZZ1Icffmieg+8kuzSF2k9TKAAAAIRSYKGjPh09etTcnzJlirk/d+5cMyM3I0L5VoO6MRIZHiYFRQ4myQMAAEBoBRY6GpRrs6jZs2f7Ok04JjwsTBrVqyV7j2TJAfpYAAAAINTmsVDaz2L//v1SVFTktv6kk07yRbrgMuSsBhZHcwokMzdf6sRE8dkAAAAg+AOLX375RUaOHCnLly93W6/zWOhs0YWFhb5Mn+0lxbuMDJWaLScnE1gAAAAgBAKLESNGmGFm582bZ0aF0mACNTNJ3r40DSzi+bgBAAAQ/IHFmjVrZNWqVdK+ffvqSRHcJCe4z74NAAAAhMQ8Fh06dPD5fBWzZs2SVq1amZm8e/XqJStXrix125dfflnOO+88qV+/vln69etX5vahVGNBYAEAAICQCSx0du37779fli5dKocOHZL09HS3paJ0qNpx48bJpEmTZPXq1dK5c2cZMGCA6Rjujb7v9ddfL0uWLJEVK1ZIixYtpH///rJnz54Kv3cwILAAAABASDaF0hoC1bdvX5903ta5L0aNGmX6bigdvvbzzz+XOXPmyPjx40ts//bbb7s9/te//iUffPCBLFq0SIYNGyahplE8s28DAAAgBAMLrSnwFR2yVvtrTJgwwbkuPDzcBC9aG1EeWVlZkp+fLw0aNPD6fG5urlksVq2KDpPrOVRuTdH31UCsPO+vE+TVrxMjRzJzTedtf6UZgZEfEPrIDyA/gOMDAul8UZH9Vziw6NOnj/iK9tXQGo7k5GS39fp48+bN5drHAw88IE2bNnXWpHiaNm2amSHc04EDByQnJ0f8Qb+gtLQ0kxk0kDqRBnUiTWBx+Giu7NmbIlERFW7BhgBW0fyA0EZ+APkBHB8QSOeLjIwM3wYW69atk44dO5pE6/2ydOrUSWrKY489Ju+++67pd6Edv73R2hDtw+FaY6H9Mho1aiTx8fF+ywjabEzTUJ6M0KzhHtm2P9PcD4utK0n169RAKhGo+QGhjfwA8gM4PiCQzhellbErHVh06dJFUlJSJCkpydzXf0KjI08V7WORmJgoERERsm/fPrf1+rhx48ZlvvaJJ54wgcVXX31VZjATExNjFk/6BfizEKefVXnTkJxQ23n/YHquNG9Yt5pTh0DODwh95AeQH8DxAYFyvqjIvssVWGzfvt1EQ9Z9X4mOjpbu3bubjteDBg1yRl/6eMyYMaW+7vHHH5epU6fKggULpEePHmK3SfIAAACAQFOuwKJly5Ze7/uCNlMaPny4CRB69uwpM2fOlMzMTOcoUTrSU7NmzUxfCWu424kTJ8o777xj5r7QmhQVFxdnllAPLPYcKm4SBQAAAASSCnfe1rkrGjZsaO7v2rXLTFiXnZ0tl19+uZm4rqKGDBliOlJrsKBBgja1mj9/vrND986dO92qYF544QUzmtQ111zjth+dB2Py5MkSito2qSdhOqSvzuOx8Q+5+cJ2Eh6mawAAAIAgCyzWr18vl112mQkm2rZtazpNDxw40NQuaMH/qaeekvfff9/ZpKkitNlTaU2ftGO2qx07dojdNKwbK91OaSSrth2QfanZsm7HIelycqK/kwUAAAA4lbs3hs62fcYZZ8g333wjF1xwgfz5z3+WSy+91AxzdeTIEbnttttMZ2pUj4FdWjjvz1+zi48ZAAAAwVlj8cMPP8jixYvNCEydO3eWl156SUaPHu1spnTXXXfJWWedVZ1ptbWzTk2S+FpRkp6dL8s2pUjGwHypWyvK38kCAAAAKlZjcfjwYecQsNpJuk6dOlK/fn3n83q/IhNooGKiIyPkwjOamfv5hUWydMMePkIAAAAEjPCKjpVb1mNUrwEuzaEWrNnNxw0AAIDgHBXq5ptvdk42l5OTI7fffrupuVC5ubnVk0I4tU6Ol1Ob1JNf9qbJ1r1psi0lXU5p7J/ZwwEAAIBKBRY614Srm266qcQ2OucEqlf/Li1MYKG+XLtL7mh8Oh85AAAAgiewePXVV6s3JSiXP3VsKi8t3Ch5BUWyaP0eGdm3vel/AQAAAARNHwv4X1xslJzbvrgTfUZ2vqzYss/fSQIAAAAILIK/EzdzWgAAAMD/qLEIQp1aNZTGCbXM/dW/HZT9adn+ThIAAABsjsAiCIWHhUn/zsW1Fg7TiZuhZwEAAOBfBBZB6qLOzcWaRURHhypyaIgBAAAA+AeBRZBKqldLup3SyNzfl5ota3cc8neSAAAAYGMEFkFsQOfmzvt04gYAAIA/EVgEsd7tkqVurShzf9mmFNl5IMPfSQIAAIBNEVgEMZ0Yzxp6Nr+wSCa/t0qO5uT7O1kAAACwIQKLIDf0/LbSOjne3N9zOFOmffiTFBbRkRsAAAA1i8AiyMVGR8qka7tL/LEmUT9uOyCvLdni72QBAADAZggsQkDjhNry4DXdzPwW6r3l22Tpz3/4O1kAAACwEQKLENGlVaLc1v805+MZn62VX/em+TVNAAAAsA8CixByxZmtzMR5KregSKb8Z5WkZub6O1kAAACwAQKLEBIWFiZ3X9JR2jVNMI/3p2XL1A9WS0Fhkb+TBgAAgBBHYBGCQ9BqZ+4GcTHm8brfD8vEuT/KwfQcfycNAAAAIYzAIgQ1rBsrDw3uLlERxV/vqm0H5NbZX8vCtbvF4WAoWgAAAPgegUWI6tC8vky5roez5iIzt0Ce+HStTJr7oxzKoPYCAAAAvkVgEcK6t24kL93eR/qe0cy57vut++XW2d/I4vV7qL0AAACAzxBYhLi6taLk/kFdZPK1PaR+neLai6M5+TL94zWm78WGXYcJMAAAAFBlkVXfBYJB73bJcnqL+vL8gg2y5NjkeSu37jdLm8bxckXPVnLB6U1N528AAACgoqixsJH42tEy/squ8tA13Zx9L9SvKeny5Kfr5KanF8trS7YwghQAAAAqjBoLGzr3tCbSs22SfLNxr3yycof8cmyG7rSsPPn3sl9l7nfbpFvrRDmnfWPpfWqy1HcJQgAAAABvCCxsSps89evU3HTs3rwnVT5euUO+3bRXCoscUuRwyI/bDpjlmc/Xy2nN68vZ7ZPlnHaNpWmDOv5OOgAAAAIQgYXN6WzdGjjocmvGaTJv1e/y5drdzuZQOuvFxt1HzPKvrzbLSYlx0vXkROnUsoF0atnQNK8CAAAA/N7HYtasWdKqVSuJjY2VXr16ycqVK0vddsOGDXL11Veb7bVAPHPmzBpNqx0m1ht+QTt56+4L5bm/nCvXn9vGBBKudh48Kp/8sEMeeX+1DH5yodz+4jfywoINsnxziqRm5vot7QAAALBxjcXcuXNl3LhxMnv2bBNUaKAwYMAA2bJliyQlJZXYPisrS1q3bi2DBw+We++91y9ptgMN2to2qWeWm//UTnYfOirLt+yT5VtSZMueVClymbx7+/4Ms2hTKpWcUEvaNU2QU5vWk/ZNE6RNk3pSK5qKMQAAgFAX5nA4XIqJNUuDiTPPPFOee+4587ioqEhatGghd911l4wfP77M12qtxdixY81SEenp6VKvXj1JS0uT+Ph48Qf9P/fv32+Cp/Bwv1caVUhmTr78vOuwrN1xSNb9fli2paS5BRqewsNETkqsK62T68rJyfFycpLejzejUmkAg+DOD/A98gPID+D4gEA6X1Sk7Oy3S8l5eXmyatUqmTBhgnOdfij9+vWTFStW+CtZOIE6sVHSq22yWazJ9n7eeVjW/X5ItvyRJlv3pklufqFzew06dhzIMIscmz9DxdeKklZJdc2iza1aNIyTFolxBBwAAABBym+BxcGDB6WwsFCSk4sLqBZ9vHnzZp+9T25urllcoy4rytPFH/R9taLIX+/vS7WjI6Rnm0ZmUYVFRbLzYKb88keqCTR++SPNBBU62pSr9Ox8U+Ohi6ta0REmyGjesI40bVBbmtQvXprWr2OCkVCs5Qil/ICqIz+A/ACODwik80VF9h/yjd+nTZsmU6ZMKbH+wIEDkpNTPPJRTdMvSKuTNDOEYtMXHZC2a9MY6dpU+8kkSX5hkexNzZFdh7Nl9+Fsc6tLalZ+iddm5xWaeTWsuTVc1YoKl6T4GLM0jIuRxLrRkhgXLYl1Y8ytBiXBKNTzAyqG/ADyAzg+IJDOFxkZGYEfWCQmJkpERITs27fPbb0+bty4sc/eR5taaQdx1xoL7cfRqFEjv/ax0Cvvmga7FCSbNRHp4bFOJ+TbdfCo7DqUaTqI7zqYKbsOHZV9qdlmmFtP2flF8vuhbLN4ExcbKY3ia0mj+FhJrBsriXp77L6uaxAXK7VjAi+WtmN+QOnIDyA/gOMDAul8oSO3lpffSlnR0dHSvXt3WbRokQwaNMj5AenjMWPG+Ox9YmJizOJJvwB/FuI0I/g7Df5WPy7WLJ1aJbqtzysolD2HMmXvkSz540iW7D2Seew2ywQdOoGfN0dzCuRoTvEoVaXRWo2GcbHSoG6MCTSKb2OkQZ0YSTh2qzON6/wc4TXY7Ir8APIDOD6A8wUCsfxQkX379fKt1iQMHz5cevToIT179jTDzWZmZsqIESPM88OGDZNmzZqZ5kxWh++NGzc67+/Zs0fWrFkjcXFx0qZNG3/+K/DxrOBmBKnkkjVKBYVFciA9R/alZcn+tGwTaOwzt8WPdWK/gjKGqdKmVrsPZ5qlLBpUJNSJlnq1o6VenWhJqB3jfJxQJ8bcavBRr1aUua1bK1oidAgsAAAAm/JrYDFkyBDT12HixImSkpIiXbp0kfnz5zs7dO/cudMtSvrjjz+ka9euzsdPPPGEWfr06SNLly71y/+AmhUZEe7s0O2N1makZebJgfTiIONARo4c0IAjI0cOH82VQ3qbkStZeQVlvo/uR7fXpTw0pIjTIKNWtOlkXleDjdhjQYe5jZK6sdFmm7hYvR917H6keS0AAECw8+s8Fv7APBZQ2XkFJsA4dLQ44NBZw63bI0dz5UhmnrnVfiDa+bw6afMsHV0rvnaMCTp0SF8NOMz9GH0cKXVidImS2sfu19b1Zl2kxERFhORoWXbFPBYgP4DjA8qDeSyAAKGzgTdrqIuOYVU6jbu1diM1M88EGRp4FN/mSXp2nqRn6W2+udX1epuZW3ZtiLfmWbocOppXqf9Fm21pp/TigKN40f/P3I+OlFrOWw1gip8zS0zE8fvR1v0IibBxvx8AAFB5gTdEDhBAtCbA1BrEREmzBmUHIRadyyNDg43sfMnIzjP3i5c8ycjJN5MK6mO9Parr9XFWrmTmFUpBYcUrELXZltlXTsnheysjKiLcGWhobYjexkZHSKx1PyrCPNbniu8fW3dsiTm2bWxU8foY5xJu9k3tCgAAoYnAAvAxveKvHbx1qWhVpnY8Lw4SCiTzWLCgNSBZucWP9X5mbr5k6vO5BaZJlz53fMmX3IKqNd3Spl/52UUmMPI17d9+PNCIkJjICI/H4abzvgYh1vPW4+JbfRxevD7Kuo2Q6Ijw4lvrOd1PVIREhocRyAAAUEMILIAAooXnBnG6VH4fOnKWNt/KtoINvZ9XaO5rIFK8FJrns/N1u0KzTU5+oeRYz+lj6za/0Gf/nw7YZTX9qgna88QKMsxtZISpNbHuF9+GS5Tr/Qj37fS5KJfnzOJ8XPyc2/pjt1EutzpiGDU1AIBQR2ABhODIWcWjU0X7ZH/a1CovvzgYsIIPc2vWFUhufqFZip9zue+yPtfzfsHxdbqUMUJwlehutQanqrU4vghwNMjQ78Y14HANSKzntJalqDBf6tT+w21b5/MRYc7HxevCiu+HH3/++LbHt9eaNOe2Http4KP3a3LuFgBA6CGwAFAmLWyafhTR1XO40A7y2gRMgxKdHFEDjTwTDBSagCbHemxuNSgpMuuP3xY/n2+9Rtcf249p1uWyPt/5XFGpEy1Wy/9oJn7U965IgJMq/viuXYMPDThM4KHrwks+tgIUK2jR20hrW+c2JR9b27ltH66Pi9/butUgy6x3ve/y2uLtjq1z2VZvCZIAoOYRWADwK20ipIXSqFo6GlVUjb2vdrIvDjSs5VjwUVh83wpKzDbWfes55/2S65y3ZdwvcHmsHfare0jj8tJgK7dAl8BIT1X782jAEa7Bh0vQEm7ddwlmrIDFClTCXR97PO/tNSaQKXO74+s14HFd7+11rttoHVJqarbkhB81Te/CvWxzfB/H19P0DoA/EFgAsCVTkIsOl1jftBjzSa2NqV3JL5B9+w9IvYT6ooOEWYGHCUZcAhNrvb6m4FiQpPsocHneeo0+b21faNYd2+7Yeudrjr3ebOfcl6ZNX1d8q+uqq+maL2kaizRgKxQp3zSXoUUDKyvIcA1ePNc5H7usd79/PECL0H3q78bcWvuz7he/rsR9j1trvVs6ju2jxHNeX1v8f5W5z2P/u+tzrttqiz/X/R+/Pb6ewAyoHAILAAiUWpuIcImNCpfc2lGSlFDbFOICkdZseAYdrsGIMygpKhmYFN+6bHdsG61BKn5d8X3rdUVF7ttbz1n3i/dx7PGx4Mhar+/lfE2R49i+rP1Yz1uvCYJoqaKB1bGAFZVzvPbHI1DxEgg510nJYCW8lKBGf/dWYGXue+w7zPP9j70+NydH6tQ+YJr9Fb/u+PP6WvMeLvt33a/r9qXt33Nfns+ZW9f/x+29ju873OP/Cqvgfks+f3w/CFwEFgCACtGTfPGoWqHzwWmtkZbBCz2CGS2cewYpVjDjfM5lvXltoetzxwMZa3+6TaGXxfU1VloKCookMytbomNijq07tq31ftZrXPbrvHVJX5HrNh5psLZzfR2KA7OiSswthOrnNYAJ9wxmPIKWY7fegp2S2x2vHXN9D29Bjl7+sZ4LKyOgKpmGst9fwyfXx00b1JZ+nZoHfPYKodMCAACVY67emqvJEQH1EbrOc1OTNVjego0iz2DFZRuv910CGdfnioqk1O093+t4ICSlrD/2WGtoytiHFZTpYxNEWtu6vM5ze7d1nuvdtndfp3GZlbbigLX4dfBl/iz+zIuHxrCH7q0TCSwAAEDwMVdbTaTl75SEBg0wtAjsGRhp2dg1SDFBict9z+cKCgvl0KHDpg+WXs4+Hsy47M8tGCp+b8/3smrorO08n7MCLms71wDJNWByvq60+0Xe11v/p+d+PNOlr1fF2x6vWXTdtqy0uO7Xes/j+yv5Gtf9B5qwIGkCRo0FAABANbKatphgrYo1WHFhOZKUVC9g+2CFCs8gxjXwsII1jRa9BTJFXp9z3Z9LsHnsOSvo8QyWrG3r1qq5UROrgsACAAAA8NY80oSEKC/CXQAAAABVRmABAAAAoMoILAAAAABUGYEFAAAAgCojsAAAAABQZQQWAAAAAKqMwAIAAABAlRFYAAAAAKgyAgsAAAAAVUZgAQAAAKDKIsVmHA6HuU1PT/dbGoqKiiQjI0NiY2MlPJzYzu7IDyA/gOMDOF8gUMsPVpnZKkOXxXaBhX4BqkWLFv5OCgAAABA0Zeh69eqVuU2YozzhR4hFd3/88YfUrVtXwsLC/JIGjfw0sNm1a5fEx8f7JQ0IHOQHkB/A8QGcLxCo5QcNFTSoaNq06QlrRmxXY6EfSPPmzSUQaCYgsAD5ARwfwPkClB8QyOXJE9VUWGjgDwAAAKDKCCwAAAAAVBmBhR/ExMTIpEmTzC1AfgDHB3C+AOUHhEL5wXadtwEAAAD4HjUWAAAAAKqMwAIAAABAlRFYAAAAAKgyAosaNmvWLGnVqpWZfr1Xr16ycuXKmk4CasC0adPkzDPPNBMxJiUlyaBBg2TLli1u2+Tk5Midd94pDRs2lLi4OLn66qtl3759btvs3LlTLr30Uqldu7bZz9/+9jcpKCjgOwxyjz32mJmgc+zYsc515Ad72bNnj9x0003m91+rVi0544wz5Mcff3Q+r90fJ06cKE2aNDHP9+vXT7Zu3eq2j8OHD8uNN95oxq9PSEiQkSNHytGjR/3w36AqCgsL5aGHHpKTTz7ZfNennHKKPPLIIyYPWMgPoeubb76Ryy67zEw+p+eFjz/+2O15X33369atk/POO8+UP3VSvccff7x6/iHtvI2a8e677zqio6Mdc+bMcWzYsMExatQoR0JCgmPfvn18BSFmwIABjldffdXx888/O9asWeO45JJLHCeddJLj6NGjzm1uv/12R4sWLRyLFi1y/Pjjj46zzjrLcfbZZzufLygocHTs2NHRr18/x08//eT44osvHImJiY4JEyb46b+CL6xcudLRqlUrR6dOnRz33HOPcz35wT4OHz7saNmypePmm292fP/9947ffvvNsWDBAsevv/7q3Oaxxx5z1KtXz/Hxxx871q5d67j88ssdJ598siM7O9u5zcCBAx2dO3d2/O9//3N8++23jjZt2jiuv/56P/1XqKypU6c6GjZs6Jg3b55j+/btjv/85z+OuLg4x9NPP+3chvwQur744gvHgw8+6Pjwww81knR89NFHbs/74rtPS0tzJCcnO2688UZTLvn3v//tqFWrluPFF1/0+f9DYFGDevbs6bjzzjudjwsLCx1NmzZ1TJs2rSaTAT/Yv3+/OWB8/fXX5nFqaqojKirKnEAsmzZtMtusWLHCebAJDw93pKSkOLd54YUXHPHx8Y7c3Fw//BeoqoyMDEfbtm0dCxcudPTp08cZWJAf7OWBBx5wnHvuuaU+X1RU5GjcuLHjn//8p3Od5pGYmBhTIFAbN240x4sffvjBuc1///tfR1hYmGPPnj3V/B/Aly699FLHLbfc4rbuqquuMoVARX6wD/EILHz13T///POO+vXru5Ud9DjUrl07n/8PNIWqIXl5ebJq1SpThWUJDw83j1esWFFTyYCfpKWlmdsGDRqYW80L+fn5bvmhffv2ctJJJznzg95q84jk5GTnNgMGDJD09HTZsGFDjf8PqDpt+qZN21y/d0V+sJdPP/1UevToIYMHDzZNHLt27Sovv/yy8/nt27dLSkqKWz6pV6+eaT7renzQJg+6H4tur+eV77//vob/I1TF2WefLYsWLZJffvnFPF67dq0sW7ZMLr74YvOY/GBf2310LNBtzj//fImOjnYrT2gT7SNHjvg0zZE+3RtKdfDgQdOO0rWQqPTx5s2b+eRCWFFRkWlLf84550jHjh3NOj1Q6A9cDwae+UGfs7bxll+s5xBc3n33XVm9erX88MMPJZ4jP9jLb7/9Ji+88IKMGzdO/u///s/kibvvvtscE4YPH+78fXv7/bseHzQocRUZGWkuXnB8CC7jx483F4z04lJERIQpK0ydOtW0mVfkB/tK8dGxQG+1D4/nPqzn6tev77M0E1gANXCV+ueffzZXoGBPu3btknvuuUcWLlxoOs7B3vRig15dfPTRR81jrbHQY8Ts2bNNYAF7ee+99+Ttt9+Wd955R04//XRZs2aNuRilnXnJDwg2NIWqIYmJieZKhOeoP/q4cePGNZUM1LAxY8bIvHnzZMmSJdK8eXPnev3OtXlcampqqflBb73lF+s5BA9t6rR//37p1q2buZKky9dffy3PPPOMua9XjsgP9qGju3To0MFt3WmnnWZGgXP9fZd1vtBbzVOudMQ4HR2G40Nw0dH+tNbiuuuuM81fhw4dKvfee68ZXVCRH+yrsY+OBTVZniCwqCFaxd29e3fTjtL1qpU+7t27d00lAzVE+2BpUPHRRx/J4sWLS1RBal6Iiopyyw/a1lELFlZ+0Nv169e7HTD0ircOJ+dZKEFg69u3r/ku9UqktegVa23qYN0nP9iHNov0HH5a29e3bNnS3NfjhZ7sXY8P2lRG20u7Hh/0woQGrRY91uh5RdtfI3hkZWWZ9vCu9EKkfpeK/GBfJ/voWKDb6LC22rfTtTzRrl07nzaDMnzeHRxlDjerPflfe+0104v/1ltvNcPNuo76g9Bwxx13mOHhli5d6ti7d69zycrKchteVIegXbx4sRlutnfv3mbxHG62f//+Zsja+fPnOxo1asRwsyHCdVQoRX6w15DDkZGRZpjRrVu3Ot5++21H7dq1HW+99ZbbEJN6fvjkk08c69atc1xxxRVeh5js2rWrGbJ22bJlZsQxhpsNPsOHD3c0a9bMOdysDjuqQ4vff//9zm3ID6E9WuBPP/1kFi2Wz5gxw9z//fffffbd60hSOtzs0KFDzXCzWh7VYw7DzYaAZ5991hQmdT4LHX5WxxxG6NGDg7dF57aw6EFh9OjRZgg4/YFfeeWVJvhwtWPHDsfFF19sxpvWE81f//pXR35+vh/+I1R3YEF+sJfPPvvMXDjQi03t27d3vPTSS27P6zCTDz30kCkM6DZ9+/Z1bNmyxW2bQ4cOmcKDznmgw1CPGDHCFFIQXNLT082xQMsGsbGxjtatW5t5DVyHBiU/hK4lS5Z4LS9owOnL717nwNBhrnUfGshqwFIdwvSPb+tAAAAAANgNfSwAAAAAVBmBBQAAAIAqI7AAAAAAUGUEFgAAAACqjMACAAAAQJURWAAAAACoMgILAAAAAFVGYAEAAACgyggsAABBpVWrVjJz5kx/JwMA4IHAAgBQqptvvlkGDRpk7l9wwQUyduzYGvu0XnvtNUlISCix/ocffpBbb721xtIBACifyHJuBwCAT+Tl5Ul0dHSlX9+oUSO+CQAIQNRYAADKVXPx9ddfy9NPPy1hYWFm2bFjh3nu559/losvvlji4uIkOTlZhg4dKgcPHnS+Vms6xowZY2o7EhMTZcCAAWb9jBkz5IwzzpA6depIixYtZPTo0XL06FHz3NKlS2XEiBGSlpbmfL/Jkyd7bQq1c+dOueKKK8z7x8fHy7XXXiv79u1zPq+v69Kli7z55pvmtfXq1ZPrrrtOMjIy+OYBwIcILAAAJ6QBRe/evWXUqFGyd+9es2gwkJqaKhdeeKF07dpVfvzxR5k/f74p1Gvh3tXrr79uaim+++47mT17dvEJKDxcnnnmGdmwYYN5fvHixXL//feb584++2wTPGigYL3ffffdVyJdRUVFJqg4fPiwCXwWLlwov/32mwwZMsRtu23btsnHH38s8+bNM4tu+9hjj/HNA4AP0RQKAHBCepVfA4PatWtL48aNneufe+45E1Q8+uijznVz5swxQccvv/wip556qlnXtm1befzxx9326dpfQ2sS/vGPf8jtt98uzz//vHkvfU+tqXB9P0+LFi2S9evXy/bt2817qjfeeENOP/100xfjzDPPdAYg2mejbt265rHWquhrp06dyrcPAD5CjQUAoNLWrl0rS5YsMc2QrKV9+/bOWgJL9+7dS7z2q6++kr59+0qzZs1MgV8L+4cOHZKsrKxyv/+mTZtMQGEFFapDhw6m07c+5xq4WEGFatKkiezfv79S/zMAwDtqLAAAlaZ9Ii677DKZPn16iee08G7RfhSutH/Gn//8Z7njjjtMrUGDBg1k2bJlMnLkSNO5W2tGfCkqKsrtsdaEaC0GAMB3CCwAAOWizZMKCwvd1nXr1k0++OADUyMQGVn+U8qqVatMwf7JJ580fS3Ue++9d8L383TaaafJrl27zGLVWmzcuNH0/dCaCwBAzaEpFACgXDR4+P77701tg476pIHBnXfeaTpOX3/99aZPgzZ/WrBggRnRqaygoE2bNpKfny/PPvus6WytIzZZnbpd309rRLQvhL6ftyZS/fr1MyNL3XjjjbJ69WpZuXKlDBs2TPr06SM9evTgmwWAGkRgAQAoFx2VKSIiwtQE6FwSOsxr06ZNzUhPGkT079/fFPK1U7b2cbBqIrzp3LmzGW5Wm1B17NhR3n77bZk2bZrbNjoylHbm1hGe9P08O39bTZo++eQTqV+/vpx//vkm0GjdurXMnTuXbxUAaliYw+Fw1PSbAgAAAAgt1FgAAAAAqDICCwAAAABVRmABAAAAoMoILAAAAABUGYEFAAAAgCojsAAAAABQZQQWAAAAAKqMwAIAAABAlRFYAAAAAKgyAgsAAAAAVUZgAQAAAKDKCCwAAAAASFX9P+rXz1Sd9eAuAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.plot([i * 10 for i in range(len(lr.loss_history))], lr.loss_history,\n",
+    "         color='steelblue', linewidth=2)\n",
+    "plt.xlabel('Iteration')\n",
+    "plt.ylabel('Binary Cross-Entropy Loss')\n",
+    "plt.title('Training Loss Curve — ifri-mini-ml-lib LogisticRegression')\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Interactive Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "249024520c48408082b4a2bd71af8651",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Feature X:', options=(np.str_('mean radius'), np.str_('mean textur…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipywidgets import interact, FloatSlider, IntSlider, Dropdown\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "feature_names = list(cancer.feature_names)\n",
+    "\n",
+    "def plot_logistic_decision(feature_x=feature_names[0], feature_y=feature_names[1],\n",
+    "                            learning_rate=0.01, max_iter=500, momentum=0.9):\n",
+    "    \"\"\"\n",
+    "    Interactive 2D decision boundary visualization.\n",
+    "    Trains logistic regression on two chosen features and plots\n",
+    "    the predicted class regions alongside test points.\n",
+    "    \"\"\"\n",
+    "    idx_x = feature_names.index(feature_x)\n",
+    "    idx_y = feature_names.index(feature_y)\n",
+    "\n",
+    "    X_2d_train = X_train_scaled[:, [idx_x, idx_y]]\n",
+    "    X_2d_test  = X_test_scaled[:, [idx_x, idx_y]]\n",
+    "\n",
+    "    model = LogisticRegression(learning_rate=learning_rate, max_iter=max_iter, momentum=momentum)\n",
+    "    model.fit(X_2d_train, y_train)\n",
+    "\n",
+    "    # Build grid\n",
+    "    x_min, x_max = X_2d_test[:, 0].min() - 0.5, X_2d_test[:, 0].max() + 0.5\n",
+    "    y_min, y_max = X_2d_test[:, 1].min() - 0.5, X_2d_test[:, 1].max() + 0.5\n",
+    "    xx, yy = np.meshgrid(np.linspace(x_min, x_max, 200), np.linspace(y_min, y_max, 200))\n",
+    "    grid = np.c_[xx.ravel(), yy.ravel()]\n",
+    "    Z = model.predict(grid).reshape(xx.shape)\n",
+    "\n",
+    "    acc = accuracy(y_test, model.predict(X_2d_test))\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "    ax.contourf(xx, yy, Z, alpha=0.25, cmap='coolwarm')\n",
+    "    scatter = ax.scatter(X_2d_test[:, 0], X_2d_test[:, 1], c=y_test,\n",
+    "                         cmap='coolwarm', edgecolors='k', s=40, linewidths=0.5)\n",
+    "    plt.colorbar(scatter, ax=ax, label='Class (0=Benign, 1=Malignant)')\n",
+    "    ax.set_xlabel(feature_x)\n",
+    "    ax.set_ylabel(feature_y)\n",
+    "    ax.set_title(f'Decision Boundary — Accuracy: {acc:.3f}')\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "interact(\n",
+    "    plot_logistic_decision,\n",
+    "    feature_x=Dropdown(options=feature_names, value=feature_names[0], description='Feature X:'),\n",
+    "    feature_y=Dropdown(options=feature_names, value=feature_names[1], description='Feature Y:'),\n",
+    "    learning_rate=FloatSlider(min=0.001, max=0.1, step=0.005, value=0.01, description='LR:'),\n",
+    "    max_iter=IntSlider(min=100, max=2000, step=100, value=500, description='Max Iter:'),\n",
+    "    momentum=FloatSlider(min=0.0, max=0.99, step=0.05, value=0.9, description='Momentum:')\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The interactive demo above visualizes the decision boundary learned by the logistic regression model in a 2D feature subspace. You can:\n",
+    "- Choose any two features from the dataset as axes\n",
+    "- Adjust the learning rate, number of iterations, and momentum coefficient\n",
+    "- Observe how the shape of the decision boundary changes, and how accuracy responds to hyperparameter choices\n",
+    "\n",
+    "Note that projecting to two features naturally loses information — the full model trained on all features will achieve higher accuracy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Real-life Applications\n",
+    "\n",
+    "Logistic regression is one of the most deployed machine learning models in production systems, valued for its interpretability and probabilistic outputs.\n",
+    "\n",
+    "**Medical Diagnosis**: Logistic regression is widely used to predict the probability of disease given patient features — for example, diagnosing breast cancer from biopsy features (as in this notebook), predicting diabetes risk from glucose levels and BMI, or screening for cardiovascular disease. Its probability outputs allow clinicians to calibrate risk thresholds according to the clinical context.\n",
+    "\n",
+    "**Credit Scoring and Loan Approval**: Banks and microfinance institutions use logistic regression to assess whether a borrower is likely to default. Each coefficient directly quantifies how much a given financial indicator (income, debt ratio, payment history) increases or decreases the default risk — a property that regulators often require for auditability.\n",
+    "\n",
+    "**Email Spam Detection**: One of the earliest large-scale applications of logistic regression was email filtering. Features such as word frequencies and sender reputation are used to estimate the probability that a message is spam, enabling thresholded filtering.\n",
+    "\n",
+    "**Marketing and Churn Prediction**: Companies predict whether a customer is likely to cancel a subscription or respond to a campaign, allowing targeted intervention. The model's probability scores enable prioritization: instead of acting on all customers equally, teams can focus on those with the highest predicted churn probability.\n",
+    "\n",
+    "**Natural Language Processing (NLP)**: As a linear classifier in a high-dimensional bag-of-words feature space, logistic regression is a strong and fast baseline for text classification tasks such as sentiment analysis, topic labeling, and intent detection."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Limitations and Challenges\n",
+    "\n",
+    "**Binary Classification Only**: The current `LogisticRegression` implementation is designed exclusively for binary classification (two classes). Multi-class problems (e.g., classifying among three or more categories) require extensions such as One-vs-Rest (OvR) or Softmax Regression, which are not yet included in `ifri-mini-ml-lib`.\n",
+    "\n",
+    "**Linear Decision Boundary by Default**: Standard logistic regression learns a linear boundary in the original feature space. While the automatic polynomial expansion (squared terms) extends this capability, it only adds degree-2 terms and does not cover all non-linear configurations. For highly complex boundaries, tree-based models or neural networks may be more appropriate.\n",
+    "\n",
+    "**Feature Scaling Required**: Gradient descent-based optimization is sensitive to feature scale. Without standardization, features with large magnitudes will dominate the gradient updates and slow or destabilize convergence. Always apply `StandardScaler` (or `MinMaxScaler`) before training, as shown in the implementation section.\n",
+    "\n",
+    "**Sensitivity to Class Imbalance**: When one class is much more frequent than the other, the model tends to be biased toward predicting the majority class. The current implementation does not handle class weights or resampling. Using the `recall` and `f1_score` metrics (rather than accuracy alone) from `ifri-mini-ml-lib` helps detect this issue.\n",
+    "\n",
+    "**Hyperparameter Sensitivity**: The model's behavior depends on `learning_rate`, `momentum`, `max_iter`, and `tol`. Poor choices can lead to slow convergence, oscillation, or premature stopping. Using the `GridSearch` or `BayesianSearch` modules from the optimization module is recommended for systematic tuning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. References\n",
+    "\n",
+    "1. *Logistic Regression*, Scikit-learn Documentation — https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+    "\n",
+    "2. Bishop, C. M. (2006). *Pattern Recognition and Machine Learning*. Springer. Chapter 4: Linear Models for Classification.\n",
+    "\n",
+    "3. Ng, A. — *CS229 Lecture Notes: Supervised Learning, Discriminative Algorithms* — https://cs229.stanford.edu/notes2022fall/main_notes.pdf\n",
+    "\n",
+    "4. Goodfellow, I., Bengio, Y., & Courville, A. (2016). *Deep Learning*. MIT Press. Chapter 6: Deep Feedforward Networks. — https://www.deeplearningbook.org/\n",
+    "\n",
+    "5. *Breast Cancer Wisconsin Dataset* — Wolberg, W. H., Street, W. N., & Mangasarian, O. L. (1994). Machine learning techniques to diagnose breast cancer from fine-needle aspirates. *Cancer Letters*, 77(2-3), 163-171."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/regression/linear_regression.ipynb
+++ b/notebooks/regression/linear_regression.ipynb
@@ -1,0 +1,793 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Linear Regression\n",
+    "**IFRI AI Classes**\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Linear Regression is one of the oldest and most widely used algorithms in machine learning and statistics. It models the relationship between one or more input features and a continuous target variable by fitting a linear equation to observed data. Despite its simplicity, it remains a strong baseline for many real-world prediction tasks and a building block for more complex models.\n",
+    "\n",
+    "The `ifri-mini-ml-lib` implementation supports both **simple linear regression** (one feature) and **multiple linear regression** (several features), with two optimization strategies: the closed-form **Ordinary Least Squares** and iterative **Gradient Descent**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Key Concepts\n",
+    "\n",
+    "### Simple Linear Regression\n",
+    "\n",
+    "Simple linear regression models the relationship between a single feature $x$ and a continuous target $y$ using a straight line:\n",
+    "\n",
+    "$$\\hat{y} = w \\cdot x + b$$\n",
+    "\n",
+    "Where:\n",
+    "- $\\hat{y}$ is the predicted value\n",
+    "- $w$ is the **slope** (coefficient/weight)\n",
+    "- $b$ is the **intercept** (bias)\n",
+    "\n",
+    "### Multiple Linear Regression\n",
+    "\n",
+    "When there are $n$ features, the model generalizes to:\n",
+    "\n",
+    "$$\\hat{y} = w_1 x_1 + w_2 x_2 + \\cdots + w_n x_n + b = \\mathbf{w}^\\top \\mathbf{x} + b$$\n",
+    "\n",
+    "In matrix form, for a dataset of $m$ samples:\n",
+    "\n",
+    "$$\\hat{\\mathbf{y}} = X\\mathbf{w} + b$$\n",
+    "\n",
+    "Where $X \\in \\mathbb{R}^{m \\times n}$ is the feature matrix.\n",
+    "\n",
+    "### Loss Function: Mean Squared Error (MSE)\n",
+    "\n",
+    "Training a linear regression model means finding the values of $\\mathbf{w}$ and $b$ that minimize the **Mean Squared Error** between predictions and true values:\n",
+    "\n",
+    "$$\\mathcal{L}(\\mathbf{w}, b) = \\frac{1}{m} \\sum_{i=1}^{m} (\\hat{y}_i - y_i)^2$$\n",
+    "\n",
+    "This loss function is convex, which guarantees that any local minimum is also a global minimum."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Optimization Methods\n",
+    "\n",
+    "The `LinearRegression` class in `ifri-mini-ml-lib` supports two methods to minimize the MSE loss.\n",
+    "\n",
+    "### Ordinary Least Squares (OLS) — `method='least_squares'`\n",
+    "\n",
+    "OLS derives the optimal parameters analytically, without iteration.\n",
+    "\n",
+    "**For simple regression**, the closed-form solution is:\n",
+    "\n",
+    "$$w = \\frac{\\sum_{i=1}^{m}(x_i - \\bar{x})(y_i - \\bar{y})}{\\sum_{i=1}^{m}(x_i - \\bar{x})^2}, \\quad b = \\bar{y} - w\\bar{x}$$\n",
+    "\n",
+    "**For multiple regression**, using the augmented feature matrix $\\tilde{X} = [\\mathbf{1} \\mid X]$:\n",
+    "\n",
+    "$$\\boldsymbol{\\theta} = (\\tilde{X}^\\top \\tilde{X})^{+} \\tilde{X}^\\top \\mathbf{y}$$\n",
+    "\n",
+    "Where $(\\cdot)^{+}$ denotes the **Moore-Penrose pseudoinverse**, which handles cases where $\\tilde{X}^\\top \\tilde{X}$ is singular.\n",
+    "\n",
+    "> **Advantage**: Exact solution in a single step.  \n",
+    "> **Limitation**: Computationally expensive for very large datasets ($O(n^3)$ matrix inversion).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Gradient Descent — `method='gradient_descent'`\n",
+    "\n",
+    "Gradient Descent is an iterative optimization method that updates the parameters in the direction of the steepest descent of the loss function.\n",
+    "\n",
+    "At each iteration $t$, the gradients of the MSE with respect to $\\mathbf{w}$ and $b$ are:\n",
+    "\n",
+    "$$\\frac{\\partial \\mathcal{L}}{\\partial \\mathbf{w}} = -\\frac{2}{m} X^\\top (\\mathbf{y} - \\hat{\\mathbf{y}}), \\quad \\frac{\\partial \\mathcal{L}}{\\partial b} = -\\frac{2}{m} \\sum_{i=1}^{m}(y_i - \\hat{y}_i)$$\n",
+    "\n",
+    "The parameters are then updated as:\n",
+    "\n",
+    "$$\\mathbf{w} \\leftarrow \\mathbf{w} - \\alpha \\frac{\\partial \\mathcal{L}}{\\partial \\mathbf{w}}, \\quad b \\leftarrow b - \\alpha \\frac{\\partial \\mathcal{L}}{\\partial b}$$\n",
+    "\n",
+    "Where $\\alpha$ is the **learning rate** — a hyperparameter controlling the step size.\n",
+    "\n",
+    "> **Advantage**: Scales well to large datasets and high-dimensional feature spaces.  \n",
+    ">**Limitation**: Requires careful tuning of `learning_rate` and `epochs`; may not converge if $\\alpha$ is too large.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "> **Note**: For most standard datasets, `least_squares` is the recommended default. Switch to `gradient_descent` when your dataset is very large or the feature matrix is ill-conditioned."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Pseudo-algorithm\n",
+    "\n",
+    "```\n",
+    "Input: X       ← matrice [n_samples, n_features]\n",
+    "       y       ← vecteur cible [n_samples]\n",
+    "       method  ← \"least_squares\" ou \"gradient_descent\"\n",
+    "       α       ← learning rate (si gradient_descent)\n",
+    "       epochs  ← nombre d'itérations (si gradient_descent)\n",
+    "\n",
+    "if method == \"least_squares\":\n",
+    "    if n_features == 1:\n",
+    "        X ← flatten(X)\n",
+    "        w ← sum((X - mean(X)) * (y - mean(y))) / sum((X - mean(X))²)\n",
+    "        b ← mean(y) - w * mean(X)\n",
+    "    else:\n",
+    "        X̃ ← [1 | X]                    # Ajout colonne de biais\n",
+    "        θ ← pinv(X̃ᵀ X̃) · X̃ᵀ · y      # Pseudoinverse\n",
+    "        b ← θ[0],  w ← θ[1:]\n",
+    "\n",
+    "elif method == \"gradient_descent\":\n",
+    "    if n_features == 1:\n",
+    "        w ← 0.0,  b ← 0.0\n",
+    "    else:\n",
+    "        w ← zeros(n_features),  b ← 0.0\n",
+    "    for t = 1 to epochs do\n",
+    "        ŷ  ← X · w + b\n",
+    "        dw ← -(2/m) · Xᵀ · (y - ŷ)\n",
+    "        db ← -(2/m) · sum(y - ŷ)\n",
+    "        w  ← w - α · dw\n",
+    "        b  ← b - α · db\n",
+    "    end for\n",
+    "\n",
+    "Return w, b\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Implementation\n",
+    "\n",
+    "For this implementation, we use the **California Housing** dataset, which contains housing data for California districts. The goal is to predict the median house value (`MedHouseVal`) from features such as median income, average number of rooms, population, etc.\n",
+    "\n",
+    "It has 20,640 samples and 8 features, making it a suitable benchmark for regression tasks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset shape : (20640, 8)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "MedInc",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "HouseAge",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "AveRooms",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "AveBedrms",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "Population",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "AveOccup",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "Latitude",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "Longitude",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "4080b817-355f-4247-8a17-44eddbcdf8e9",
+       "rows": [
+        [
+         "0",
+         "8.3252",
+         "41.0",
+         "6.984126984126984",
+         "1.0238095238095237",
+         "322.0",
+         "2.5555555555555554",
+         "37.88",
+         "-122.23"
+        ],
+        [
+         "1",
+         "8.3014",
+         "21.0",
+         "6.238137082601054",
+         "0.9718804920913884",
+         "2401.0",
+         "2.109841827768014",
+         "37.86",
+         "-122.22"
+        ],
+        [
+         "2",
+         "7.2574",
+         "52.0",
+         "8.288135593220339",
+         "1.073446327683616",
+         "496.0",
+         "2.8022598870056497",
+         "37.85",
+         "-122.24"
+        ],
+        [
+         "3",
+         "5.6431",
+         "52.0",
+         "5.8173515981735155",
+         "1.0730593607305936",
+         "558.0",
+         "2.547945205479452",
+         "37.85",
+         "-122.25"
+        ],
+        [
+         "4",
+         "3.8462",
+         "52.0",
+         "6.281853281853282",
+         "1.0810810810810811",
+         "565.0",
+         "2.1814671814671813",
+         "37.85",
+         "-122.25"
+        ]
+       ],
+       "shape": {
+        "columns": 8,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>MedInc</th>\n",
+       "      <th>HouseAge</th>\n",
+       "      <th>AveRooms</th>\n",
+       "      <th>AveBedrms</th>\n",
+       "      <th>Population</th>\n",
+       "      <th>AveOccup</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>Longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8.3252</td>\n",
+       "      <td>41.0</td>\n",
+       "      <td>6.984127</td>\n",
+       "      <td>1.023810</td>\n",
+       "      <td>322.0</td>\n",
+       "      <td>2.555556</td>\n",
+       "      <td>37.88</td>\n",
+       "      <td>-122.23</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>8.3014</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>6.238137</td>\n",
+       "      <td>0.971880</td>\n",
+       "      <td>2401.0</td>\n",
+       "      <td>2.109842</td>\n",
+       "      <td>37.86</td>\n",
+       "      <td>-122.22</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7.2574</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>8.288136</td>\n",
+       "      <td>1.073446</td>\n",
+       "      <td>496.0</td>\n",
+       "      <td>2.802260</td>\n",
+       "      <td>37.85</td>\n",
+       "      <td>-122.24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>5.6431</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>5.817352</td>\n",
+       "      <td>1.073059</td>\n",
+       "      <td>558.0</td>\n",
+       "      <td>2.547945</td>\n",
+       "      <td>37.85</td>\n",
+       "      <td>-122.25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3.8462</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>6.281853</td>\n",
+       "      <td>1.081081</td>\n",
+       "      <td>565.0</td>\n",
+       "      <td>2.181467</td>\n",
+       "      <td>37.85</td>\n",
+       "      <td>-122.25</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   MedInc  HouseAge  AveRooms  AveBedrms  Population  AveOccup  Latitude  \\\n",
+       "0  8.3252      41.0  6.984127   1.023810       322.0  2.555556     37.88   \n",
+       "1  8.3014      21.0  6.238137   0.971880      2401.0  2.109842     37.86   \n",
+       "2  7.2574      52.0  8.288136   1.073446       496.0  2.802260     37.85   \n",
+       "3  5.6431      52.0  5.817352   1.073059       558.0  2.547945     37.85   \n",
+       "4  3.8462      52.0  6.281853   1.081081       565.0  2.181467     37.85   \n",
+       "\n",
+       "   Longitude  \n",
+       "0    -122.23  \n",
+       "1    -122.22  \n",
+       "2    -122.24  \n",
+       "3    -122.25  \n",
+       "4    -122.25  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.datasets import fetch_california_housing\n",
+    "from ifri_mini_ml_lib.preprocessing.preparation import DataSplitter\n",
+    "\n",
+    "\n",
+    "housing = fetch_california_housing()\n",
+    "X = pd.DataFrame(housing.data, columns=housing.feature_names)\n",
+    "y = pd.Series(housing.target, name='MedHouseVal')\n",
+    "\n",
+    "print(f\"Dataset shape : {X.shape}\")\n",
+    "X.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "splitter = DataSplitter(seed=42)\n",
+    "X_train, X_test, y_train, y_test = splitter.train_test_split(X, y, test_size=0.2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With Scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sklearn.linear_model import LinearRegression as SklearnLR\n",
+    "\n",
+    "start_1 = time.perf_counter()\n",
+    "sk_model = SklearnLR()\n",
+    "sk_model.fit(X_train, y_train)\n",
+    "end_1 = time.perf_counter()\n",
+    "\n",
+    "y_pred_sk = sk_model.predict(X_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With ifri-mini-ml-lib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ifri_mini_ml_lib.regression import LinearRegression\n",
+    "\n",
+    "# Scikit-learn\n",
+    "start_1 = time.perf_counter()\n",
+    "sk_model = SklearnLR()\n",
+    "sk_model.fit(X_train, y_train)\n",
+    "end_1 = time.perf_counter()\n",
+    "y_pred_sk = sk_model.predict(X_test)\n",
+    "\n",
+    "# ifri-mini — Least Squares\n",
+    "start_2 = time.perf_counter()\n",
+    "lr_ols = LinearRegression(method=\"least_squares\")\n",
+    "lr_ols.fit(X_train, y_train)\n",
+    "end_2 = time.perf_counter()\n",
+    "y_pred_ols = lr_ols.predict(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "Metric",
+         "rawType": "str",
+         "type": "string"
+        },
+        {
+         "name": "Scikit-learn",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ifri-mini (OLS)",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "4f7d880d-eeef-498b-b2df-975700ee6475",
+       "rows": [
+        [
+         "R²",
+         "0.5757877060324508",
+         "0.5757877060566212"
+        ],
+        [
+         "RMSE",
+         "0.7455813830127764",
+         "0.7455813829915358"
+        ],
+        [
+         "MAE",
+         "0.5332001304956567",
+         "0.5332001304516897"
+        ],
+        [
+         "MAPE",
+         "31.95218741361491",
+         "31.95218740361794"
+        ],
+        [
+         "Time (s)",
+         "0.009207",
+         "0.010678"
+        ]
+       ],
+       "shape": {
+        "columns": 2,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Scikit-learn</th>\n",
+       "      <th>ifri-mini (OLS)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Metric</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>R²</th>\n",
+       "      <td>0.575788</td>\n",
+       "      <td>0.575788</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>RMSE</th>\n",
+       "      <td>0.745581</td>\n",
+       "      <td>0.745581</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MAE</th>\n",
+       "      <td>0.533200</td>\n",
+       "      <td>0.533200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MAPE</th>\n",
+       "      <td>31.952187</td>\n",
+       "      <td>31.952187</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Time (s)</th>\n",
+       "      <td>0.009207</td>\n",
+       "      <td>0.010678</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          Scikit-learn  ifri-mini (OLS)\n",
+       "Metric                                 \n",
+       "R²            0.575788         0.575788\n",
+       "RMSE          0.745581         0.745581\n",
+       "MAE           0.533200         0.533200\n",
+       "MAPE         31.952187        31.952187\n",
+       "Time (s)      0.009207         0.010678"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from ifri_mini_ml_lib.metrics.regression import evaluate_rg_model\n",
+    "\n",
+    "m_sk  = evaluate_rg_model(y_test.tolist(), y_pred_sk)\n",
+    "m_ols = evaluate_rg_model(y_test.tolist(), y_pred_ols)\n",
+    "\n",
+    "results = pd.DataFrame({\n",
+    "    'Metric': ['R²', 'RMSE', 'MAE', 'MAPE', 'Time (s)'],\n",
+    "    'Scikit-learn': [\n",
+    "        m_sk['R²'], m_sk['RMSE'], m_sk['MAE'], m_sk['MAPE'],\n",
+    "        round(end_1 - start_1, 6)\n",
+    "    ],\n",
+    "    'ifri-mini (OLS)': [\n",
+    "        m_ols['R²'], m_ols['RMSE'], m_ols['MAE'], m_ols['MAPE'],\n",
+    "        round(end_2 - start_2, 6)\n",
+    "    ],\n",
+    "})\n",
+    "\n",
+    "results.set_index('Metric')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Interactive Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fa7591ea60214b6e9b2ece1928fc16d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Feature:', options=('MedInc', 'HouseAge', 'AveRooms', 'AveBedrms',…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from ipywidgets import interact, Dropdown, FloatSlider, IntSlider\n",
+    "from ifri_mini_ml_lib.preprocessing.preparation import DataSplitter\n",
+    "from ifri_mini_ml_lib.regression.linear_regression import LinearRegression\n",
+    "from ifri_mini_ml_lib.metrics.regression import evaluate_rg_model\n",
+    "\n",
+    "feature_names = housing.feature_names\n",
+    "\n",
+    "def plot_linear_regression(feature=feature_names[0], method='least_squares', learning_rate=0.01, epochs=500):\n",
+    "    idx = list(feature_names).index(feature)\n",
+    "\n",
+    "    x_series = pd.DataFrame(housing.data[:, idx], columns=[feature])\n",
+    "    y_series  = pd.Series(housing.target, name='target')\n",
+    "\n",
+    "    splitter = DataSplitter(seed=42)\n",
+    "    x_tr, x_te, y_tr, y_te = splitter.train_test_split(x_series, y_series, test_size=0.2)\n",
+    "    x_tr, x_te = x_tr.values, x_te.values\n",
+    "    y_tr, y_te = y_tr.values, y_te.values\n",
+    "\n",
+    "    # Normalisation manuelle pour éviter l'overflow en gradient descent\n",
+    "    x_mean, x_std = x_tr.mean(), x_tr.std() + 1e-8\n",
+    "    x_tr_scaled = (x_tr - x_mean) / x_std\n",
+    "    x_te_scaled  = (x_te - x_mean) / x_std\n",
+    "\n",
+    "    model = LinearRegression(method=method, learning_rate=learning_rate, epochs=epochs)\n",
+    "    model.fit(x_tr_scaled, y_tr)\n",
+    "    y_hat = model.predict(x_te_scaled)\n",
+    "\n",
+    "    metrics = evaluate_rg_model(y_te.tolist(), y_hat)\n",
+    "\n",
+    "    x_line = np.linspace(x_te.min(), x_te.max(), 100).reshape(-1, 1)\n",
+    "    x_line_scaled = (x_line - x_mean) / x_std\n",
+    "    y_line = model.predict(x_line_scaled)\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "    ax.scatter(x_te, y_te, alpha=0.3, s=10, label='Test data')\n",
+    "    ax.plot(x_line, y_line, color='red', linewidth=2,\n",
+    "            label=f\"R²={metrics['R²']:.3f}\")\n",
+    "    ax.set_xlabel(feature)\n",
+    "    ax.set_ylabel('Median House Value')\n",
+    "    ax.set_title(f'Linear Regression — {feature} | {method}')\n",
+    "    ax.legend()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "interact(\n",
+    "    plot_linear_regression,\n",
+    "    feature=Dropdown(options=feature_names, value='MedInc', description='Feature:'),\n",
+    "    method=Dropdown(options=['least_squares', 'gradient_descent'], description='Method:'),\n",
+    "    learning_rate=FloatSlider(min=0.001, max=0.1, step=0.001, value=0.01, description='LR:'),\n",
+    "    epochs=IntSlider(min=100, max=2000, step=100, value=500, description='Epochs:')\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The interactive demo above allows you to:\n",
+    "- Select any feature from the California Housing dataset and visualize how it correlates with house prices\n",
+    "- Switch between `least_squares` and `gradient_descent` to compare optimization strategies\n",
+    "- Tune the learning rate and number of epochs when using gradient descent, and observe its effect on the fit quality (R²)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "## 6. Real-life Applications\n",
+    "\n",
+    "Linear regression, despite its simplicity, powers a wide range of real-world systems.\n",
+    "\n",
+    "**Real Estate and Housing Markets**: Linear regression is used to estimate property prices based on features such as location, surface area, number of rooms, and proximity to amenities. Models similar to the one above are deployed by platforms like Zillow to provide automated property valuations.\n",
+    "\n",
+    "**Agriculture and Crop Yield Prediction**: In precision agriculture, linear regression models trained on soil quality, rainfall, and temperature data help predict crop yields at a regional level, supporting food security planning. This is especially relevant in West Africa, where initiatives like [FAOSTAT](https://www.fao.org/faostat) collect the kind of data such models require.\n",
+    "\n",
+    "**Economics and Financial Forecasting**: Economists use multiple linear regression to model relationships between macroeconomic variables — for example, how GDP growth depends on inflation, interest rates, and government spending. Central banks and investment firms use similar approaches for short-term forecasting.\n",
+    "\n",
+    "**Healthcare**: Linear regression is used to model clinical outcomes — for example, predicting a patient's hospital stay duration or medication dosage based on body weight and biological markers. It also appears in epidemiological studies linking environmental factors to disease rates.\n",
+    "\n",
+    "**Energy Sector**: Energy companies apply linear regression to forecast electricity demand based on temperature, time of day, and population density. This allows better grid management and reduces waste."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Limitations and Challenges\n",
+    "\n",
+    "**Linearity Assumption**: Linear regression assumes that the relationship between inputs and output is linear. When this assumption is violated — for example, when the true relationship is quadratic or exponential — the model will underfit and produce poor predictions. The `PolynomialRegression` class in `ifri-mini-ml-lib` addresses this by expanding features to higher-degree terms.\n",
+    "\n",
+    "**Sensitivity to Outliers**: Because MSE squares the errors, outliers exert a disproportionately large influence on the learned parameters. A single extreme value can shift the regression line significantly. Robust alternatives (e.g., using MAE as the loss) exist but are not part of the current implementation.\n",
+    "\n",
+    "**Multicollinearity**: When input features are highly correlated with each other, the OLS solution becomes unstable — small changes in the data lead to large swings in the estimated coefficients. The pseudoinverse used in `_fit_multiple` mitigates numerical failures, but the resulting coefficients may still be unreliable. Regularization techniques (Ridge, Lasso) are the standard remedy.\n",
+    "\n",
+    "**Feature Scaling for Gradient Descent**: The gradient descent method is sensitive to the scale of input features. If features have very different magnitudes, convergence can be slow or unstable. Applying `StandardScaler` or `MinMaxScaler` from the preprocessing module before training with gradient descent is strongly recommended.\n",
+    "\n",
+    "**No Uncertainty Quantification**: The `LinearRegression` class returns point predictions only. It does not provide confidence intervals or prediction intervals around its estimates, which limits its usefulness in decision-making contexts where uncertainty matters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. References\n",
+    "\n",
+    "1. *Linear Regression*, Scikit-learn Documentation — https://scikit-learn.org/stable/modules/linear_model.html\n",
+    "\n",
+    "2. Bishop, C. M. (2006). *Pattern Recognition and Machine Learning*. Springer. Chapter 3: Linear Models for Regression.\n",
+    "\n",
+    "3. Hastie, T., Tibshirani, R., & Friedman, J. (2009). *The Elements of Statistical Learning* (2nd ed.). Springer. — https://hastie.su.domains/ElemStatLearn/\n",
+    "\n",
+    "4. *Gradient Descent for Linear Regression* — Andrew Ng, Machine Learning Specialization, Coursera — https://www.coursera.org/specializations/machine-learning-introduction\n",
+    "\n",
+    "5. *California Housing Dataset*, StatLib — Pace, R. K. & Barry, R. (1997). Sparse Spatial Autoregressions. *Statistics and Probability Letters*, 33(3), 291–297."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Ajout des notebooks de documentation interactifs pour les modules de régression 
linéaire et de régression logistique . Le dossier notebooks/regression/ n'existait pas encore dans le projet, il a 
donc été créé pour l'occasion. Chaque notebook couvre les concepts clés avec 
formules mathématiques, le pseudo-algorithme, un benchmark ifri-mini-ml-lib vs 
scikit-learn, une démo interactive avec ipywidgets, ainsi que les applications 
réelles, limitations et références. Les datasets utilisés sont California Housing 
pour la régression linéaire et Breast Cancer Wisconsin pour la régression logistique.